### PR TITLE
Patched sandbox policy to quit sandboxing upon SYS_exit_group()

### DIFF
--- a/coderunner/Sandbox/liusandbox.py
+++ b/coderunner/Sandbox/liusandbox.py
@@ -54,6 +54,10 @@ if __name__ == '__main__':
         s.run()
         retCode = symbol.get(s.result, 'NA')
         details = s.probe(False)
+        
+        # monkey-patch probe details from policy status
+        if hasattr(s.policy, 'details'):
+            details.update(s.policy.details)
 
         outputFile.seek(0)
         stderrFile.seek(0)


### PR DESCRIPTION
This patch may hopefully resolve a very rare issue when `libsandbox` returns `IE` (internal error) at the termination of sandboxed programs. The patch also unified the mixed use of `machine` v.s. `arch` and `SandboxAction` v.s. `self.{_KILL_RF,_CONT}`.
