### PR TITLE
Fix a subtle bug in backup and restore

### DIFF
--- a/backup/moodle2/backup_qtype_coderunner_plugin.class.php
+++ b/backup/moodle2/backup_qtype_coderunner_plugin.class.php
@@ -79,7 +79,7 @@ class backup_qtype_coderunner_plugin extends backup_qtype_plugin {
         $testcases->add_child($testcase);
 
         // Set the source.
-        $testcase->set_source_table("question_coderunner_tests", array('questionid' => backup::VAR_PARENTID));
+        $testcase->set_source_table("question_coderunner_tests", array('questionid' => backup::VAR_PARENTID), 'id ASC');
     }
 
 

--- a/tests/behat/backup_and_restore.feature
+++ b/tests/behat/backup_and_restore.feature
@@ -1,0 +1,64 @@
+@qtype @qtype_coderunner
+Feature: Test duplicating a quiz containing a CodeRunner question
+  In order re-use my courses containing CodeRunner questions
+  As a teacher
+  I need to be able to back them up and restore them
+
+  Background:
+    And the following "courses" exist:
+      | fullname | shortname | category |
+      | Course 1 | C1        | 0        |
+    And the following "question categories" exist:
+      | contextlevel | reference | name           |
+      | Course       | C1        | Test questions |
+    And the following "questions" exist:
+      | questioncategory | qtype      | name            | template |
+      | Test questions   | coderunner | Square function | sqr      |
+    And the following "activities" exist:
+      | activity   | name      | course | idnumber |
+      | quiz       | Test quiz | C1     | quiz1    |
+    And quiz "Test quiz" contains the following questions:
+      | Square function | 1 |
+    And I log in as "admin"
+    And I am on site homepage
+    And I follow "Course 1"
+
+  @javascript
+  Scenario: Backup and restore a course containing a CodeRunner question
+    When I backup "Course 1" course using this options:
+      | Confirmation | Filename | test_backup.mbz |
+    And I restore "test_backup.mbz" backup into a new course using this options:
+      | Schema | Course name | Course 2 |
+    And I navigate to "Question bank" node in "Course administration"
+    And I click on "Edit" "link" in the "Square function" "table_row"
+    Then the following fields match these values:
+      | Question name                  | Square function                                 |
+      | Question text                  | Write a function sqr(n) that returns n squared. |
+      | General feedback               | No feedback available for coderunner questions. |
+      | Default mark                   | 31                                              |
+      | Penalty for each incorrect try | 33.33333%                                       |
+      | id_testcode_0                  | print(sqr(0))                                   |
+      | id_expected_0                  | 0                                               |
+      | id_display_0                   | Show                                            |
+      | id_mark_0                      | 1                                               |
+      | id_ordering_0                  | 0                                               |
+      | id_testcode_1                  | print(sqr(1))                                   |
+      | id_expected_1                  | 1                                               |
+      | id_display_1                   | Show                                            |
+      | id_mark_1                      | 2                                               |
+      | id_ordering_1                  | 10                                              |
+      | id_testcode_2                  | print(sqr(11))                                  |
+      | id_expected_2                  | 121                                             |
+      | id_display_2                   | Show                                            |
+      | id_mark_2                      | 4                                               |
+      | id_ordering_2                  | 20                                              |
+      | id_testcode_3                  | print(sqr(-7))                                  |
+      | id_expected_3                  | 49                                              |
+      | id_display_3                   | Show                                            |
+      | id_mark_3                      | 8                                               |
+      | id_ordering_3                  | 30                                              |
+      | id_testcode_4                  | print(sqr(-6))                                  |
+      | id_expected_4                  | 36                                              |
+      | id_display_4                   | Hide                                            |
+      | id_mark_4                      | 16                                              |
+      | id_ordering_4                  | 40                                              |

--- a/tests/behat/create_sqr_function.feature
+++ b/tests/behat/create_sqr_function.feature
@@ -1,6 +1,6 @@
 @qtype @qtype_coderunner @javascript
-Feature: create_sqr_function
-  In order to use a CodeRunner question in a quiz
+Feature: Create a coderunner question (sql function)
+  In order to test my students' programming ability
   As a teacher
   I need to create a new CodeRunner question
 

--- a/tests/helper.php
+++ b/tests/helper.php
@@ -65,6 +65,44 @@ class qtype_coderunner_test_helper extends question_test_helper {
     }
 
     /**
+     * Gets the form data that would come back when the editing form is saved,
+     * if you were creating the standard sql question.
+     * @return stdClass the form data.
+     */
+    public function get_coderunner_question_form_data_sqr() {
+        $form = new stdClass();
+
+        $form->coderunnertype = 'python3';
+        $form->customise = 0;
+        $form->showsource = 0;
+        $form->answerboxlines = 18;
+        $form->answerboxcolumns = 100;
+        $form->useace = 1;
+        $form->allornothing = 0;
+        $form->grader = 'EqualityGrader';
+        $form->prototypetype = 0;
+        $form->sandbox = 'DEFAULT';
+        $form->language = 'python3';
+        $form->enablecombinator = 1;
+        $form->testsplitterre = '|#<ab@17943918#@>#\n|ms';
+        $form->name = 'Square function';
+        $form->questiontext = array('text' => 'Write a function sqr(n) that returns n squared.', 'format' => FORMAT_HTML);
+        $form->defaultmark = 31.0;
+        $form->generalfeedback = array('text' => 'No feedback available for coderunner questions.', 'format' => FORMAT_HTML);
+        $form->penalty = 0.3333333;
+
+        $form->testcode = array('print(sqr(0))', 'print(sqr(1))', 'print(sqr(11))', 'print(sqr(-7))', 'print(sqr(-6))');
+        $form->stdin = array('', '', '', '', '');
+        $form->expected = array('0', '1', '121', '49', '36');
+        $form->extra = array('', '', '', '', '');
+        $form->display = array('SHOW', 'SHOW', 'SHOW', 'SHOW', 'HIDE');
+        $form->mark = array('1.0', '2.0', '4.0', '8.0', '16.0');
+        $form->ordering = array('0', '10', '20', '30', '40');
+
+        return $form;
+    }
+
+    /**
      * Makes a coderunner python3-pylint-func question asking for a sqr() function
      * @return qtype_coderunner_question
      */


### PR DESCRIPTION
... with the Behat test that found it.

To explain, by default, backup and restore does not guarantee to
preserve the order of rows from a table. If that matters, you have to
specify an explicit order.