### PR TITLE
Move styling of diffs out of HTML and to styles.css

### DIFF
--- a/amd/src/showdiff.js
+++ b/amd/src/showdiff.js
@@ -167,7 +167,7 @@ define(['jquery'], function($) {
     function showDifferences(firstEl, secondEl) {
         var splitter = '',
             showNls = true,
-            openDelTag = '<del style="background-color: #E0E000">',
+            openDelTag = '<del>',
             closeDelTag = '</del>',
             seq1,
             seq2,

--- a/styles.css
+++ b/styles.css
@@ -98,11 +98,7 @@ div.coderunner-test-results.partial {
 */
 .que.coderunner div.coderunner-test-results del {
     text-decoration: none;
-}
-
-.que.coderunner div.coderunner-test-results ins {
-    display: none;
-    text-decoration: none;
+    background-color: #E0E000;
 }
 
 /* Add lines I seem to have somehow overridden in styles.php */

--- a/tests/behat/behat_coderunner.php
+++ b/tests/behat/behat_coderunner.php
@@ -41,17 +41,10 @@ class behat_coderunner extends behat_base {
      * @param string $expected The string that we expect to find
      */
     public function i_should_see_highlighted($expected) {
-        $insxpath = "//ins[contains(@style, 'background-color') " .
-                "and not(contains(@style, 'background-color: inherit')) " .
-                "and not(contains(@style, 'display: none')) ".
-                "and contains(text(), '{$expected}')]";
-        $delxpath = "//del[contains(@style, 'background-color') " .
-                "and not(contains(@style, 'background-color: inherit')) " .
-                "and not(contains(@style, 'display: none')) " .
-                "and contains(text(), '{$expected}')]";
-        $msg = "'{$expected}' not found within a highlighted del or ins element";
+        $delxpath = "//div[contains(@class, 'coderunner-test-results')]//del[contains(text(), '{$expected}')]";
+        $msg = "'{$expected}' not found within a highlighted del element";
         $driver = $this->getSession()->getDriver();
-        if (!$driver->find($insxpath) && ! $driver->find($delxpath)) {
+        if (! $driver->find($delxpath)) {
             throw new ExpectationException($msg, $this->getSession());
         }
     }


### PR DESCRIPTION
I think it is better to avoid inline styles if possible. It is much easier for different themes to override styles.css than inline styles.