### PR TITLE
Fix invalid HTML

### DIFF
--- a/bulktest.php
+++ b/bulktest.php
@@ -26,7 +26,6 @@
 
 require_once(__DIR__ . '/../../../config.php');
 require_once($CFG->libdir . '/questionlib.php');
-require_once(__DIR__  . '/classes/bulk_tester.php');
 
 // Get the parameters from the URL.
 $contextid = required_param('contextid', PARAM_INT);

--- a/bulktestall.php
+++ b/bulktestall.php
@@ -26,7 +26,6 @@
 
 require_once(__DIR__ . '/../../../config.php');
 require_once($CFG->libdir . '/questionlib.php');
-require_once(__DIR__  . '/classes/bulk_tester.php');
 
 // Get the parameters from the URL. This is an option to restart the process
 // in the middle. Useful if it crashes.

--- a/bulktestindex.php
+++ b/bulktestindex.php
@@ -24,10 +24,7 @@
  */
 
 require_once(__DIR__.'/../../../config.php');
-
 require_once($CFG->libdir . '/questionlib.php');
-
-require_once(__DIR__  . '/classes/bulk_tester.php');
 
 // Login and check permissions.
 $context = context_system::instance();

--- a/classes/bulk_tester.php
+++ b/classes/bulk_tester.php
@@ -67,6 +67,8 @@ class qtype_coderunner_bulk_tester  {
             $questiontestsurl->param('courseid', $context->instanceid);
         } else if ($context->contextlevel == CONTEXT_MODULE) {
             $questiontestsurl->param('cmid', $context->instanceid);
+        } else {
+            $questiontestsurl->param('courseid', SITEID);
         }
         $numpasses = 0;
         $failingtests = array();

--- a/db/install.xml
+++ b/db/install.xml
@@ -26,7 +26,7 @@
         <FIELD NAME="showmark" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="0" SEQUENCE="false" COMMENT="True if the mark column of the results table is to be displayed to students.  DEFUNCT. See resultcolumns."/>
         <FIELD NAME="resultcolumns" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" COMMENT="A JSON record defining which result fields to display in the results table and what column name to use."/>
         <FIELD NAME="template" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="The template for this question, expanded by Twig to yield the program to be executed."/>
-        <FIELD NAME="iscombinatortemplate" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="0" SEQUENCE="false" COMMENT="True iff the template is a combinator template, i.e. takes a list of test cases rather than a single one."/>
+        <FIELD NAME="iscombinatortemplate" TYPE="int" LENGTH="1" NOTNULL="false" SEQUENCE="false" COMMENT="True iff the template is a combinator template, i.e. takes a list of test cases rather than a single one."/>
         <FIELD NAME="combinatortemplate" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="DEFUNCT: An optional template to be used to combine all tests into a single run"/>
         <FIELD NAME="testsplitterre" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" COMMENT="The regular expression argument to preg_split to split output from the combinator run into the basic tests again. Meaningful only if combinator template provided"/>
         <FIELD NAME="pertesttemplate" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="DEFUNCT: A template to build a test run for each test case. Required."/>
@@ -41,7 +41,7 @@
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-        <KEY NAME="questionid" TYPE="foreign" FIELDS="questionid" REFTABLE="questions" REFFIELDS="id"/>
+        <KEY NAME="questionid" TYPE="foreign" FIELDS="questionid" REFTABLE="question" REFFIELDS="id"/>
       </KEYS>
       <INDEXES>
         <INDEX NAME="coderunnertype" UNIQUE="false" FIELDS="coderunnertype"/>
@@ -64,7 +64,7 @@
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-        <KEY NAME="questionid" TYPE="foreign" FIELDS="questionid" REFTABLE="questions" REFFIELDS="id"/>
+        <KEY NAME="questionid" TYPE="foreign" FIELDS="questionid" REFTABLE="question" REFFIELDS="id"/>
       </KEYS>
     </TABLE>
   </TABLES>

--- a/renderer.php
+++ b/renderer.php
@@ -261,7 +261,6 @@ class qtype_coderunner_renderer extends qtype_renderer {
 
         $table = new html_table();
         $table->attributes['class'] = 'coderunner-test-results';
-        $table->attributes['name'] = 'coderunner-test-results';
 
         // Build the table header, containing all the specified field headers,
         // unless all rows in that column would be blank.


### PR DESCRIPTION
Name is not allowed on table elements. As far as I can see, it is not used anywhere, so safe to remove.