### PR TITLE
Fix warning when you run the unit tests

### DIFF
--- a/tests/coderunnertestcase.php
+++ b/tests/coderunnertestcase.php
@@ -65,7 +65,7 @@ class qtype_coderunner_testcase extends advanced_testcase {
     // to conditionally skip later tests. See jobesendbox_test.
     // Name can't be made moodle-standards compliant as it's defined by phpunit.
     // $e is the exception to be thrown.
-    protected function onNotSuccessfulTest($e) {
+    protected function onNotSuccessfulTest(Exception $e) {
         $this->hasfailed = true;
         throw $e;
     }


### PR DESCRIPTION
We were getting a warning

Strict standards: Declaration of qtype_coderunner_testcase::onNotSuccessfulTest() should be compatible with PHPUnit_Framework_TestCase::onNotSuccessfulTest(Exception $e) in /var/www/html/20170203_020059_999_tt_overnight_full/question/type/coderunner/tests/coderunnertestcase.php on line 99

This seems to be the required fix.