### PR TITLE
Feedback heading level for 'Syntax Error(s) should be h5 #heading_hie…

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -155,7 +155,7 @@ class qtype_coderunner_renderer extends qtype_renderer {
             $fb .= html_writer::tag('p', s($outcome->errormessage),
                     array('class' => 'run_failed_error'));
         } else if ($outcome->has_syntax_error()) {
-            $fb .= html_writer::tag('h3', get_string('syntax_errors', 'qtype_coderunner'));
+            $fb .= html_writer::tag('h5', get_string('syntax_errors', 'qtype_coderunner'));
             $fb .= html_writer::tag('pre', s($outcome->errormessage),
                     array('class' => 'pre_syntax_error'));
         } else if ($outcome->combinator_error()) {


### PR DESCRIPTION
…rarchy
Hi Richard, My name is Mahmoud Kassaei and I am one of the Moodle developer at the OU working on some minor accessibility issues with regards to coderunner. 

Heading level nesting is wrong in the Feedback area. This is one the accessibility issues as a result of an accessibility testing at the Open University. 