### PR TITLE
ace fold widget arrows should show on highcontrast mode #highcontrast

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -159,6 +159,53 @@ div.coderunner-test-results.partial {
     float: right;
 }
 
+.que.coderunner .ace_wrapper {
+    border: 1px solid #d9edf7;
+}
+
+.que.coderunner .ace_gutter-cell {
+    border-right: solid 1px #000000;
+}
+
+.que.coderunner .ace_fold-widget {
+    background-color: transparent;
+    background-image: none;
+    border: none;
+}
+
+.que.coderunner .ace_fold-widget:hover {
+    border: 1px solid gray;
+    margin-top: 1px;
+}
+
+/* expand */
+.que.coderunner .ace_fold-widget.ace_closed::before {
+    content: '►';
+    color: gray;
+    font-size: 80%;
+    margin: 0 2px;
+    margin-top: -4px;
+}
+
+/* collapse */
+.que.coderunner .ace_fold-widget.ace_open::before {
+    content: '▼';
+    color: gray;
+    font-size: 60%;
+    margin: 0 2px;
+}
+
+.que.coderunner .ace_line .ace_fold {
+    padding-right: 1px;
+    line-height: 9px;
+}
+
+.que.coderunner .ace_line .ace_fold::before {
+    background-image: none;
+    content: '←→';
+    float: right;
+    margin-top: -1px;
+}
 
 /* Editing form. */
 body#page-question-type-coderunner div.edit_code textarea {


### PR DESCRIPTION
The 'ace fold widget' which uses arrow icons that allow users to expand and collapse a chunk of code such as functions/methods, ..., is very confusing for users in high contrast mode, because the arrow icons do not show (e.g. IE11 in high contrast mode).

After the result of our accessibility testing at the OU, I have done some CSS changes so that users in high contrast mode have the similar experience.

To start with I have put the css changes within
@media screen and (-ms-high-contrast: active) {
.....
}
However, we then decided to get rid of the browser specific tag and therefore tried to replicate the existing arrow icons with symbols and they look very similar to the original icons.