### PR TITLE
New features to author form related to editing and testing test cases

### DIFF
--- a/amd/src/authorform.js
+++ b/amd/src/authorform.js
@@ -266,6 +266,16 @@ define(['jquery'], function($) {
         });
 
         observer.observe(preloadHdr.get(0), {'attributes': true});
+
+        // insert buttons that allow users to replace the expected output 
+        // with output got from testing the answer program
+        $('<button type="button">&lt;&lt;</button>').click(
+            function() {
+                var gotPre = $(this).prev('[id^="id_got_"]');
+                var testCaseId = gotPre.attr('id').replace('id_got_', '');
+                $('#id_expected_' + testCaseId).val(gotPre.text())
+            }
+        ).insertAfter('[id^="id_got_"]')
     }
 
     return {initEditForm: initEditForm};

--- a/amd/src/authorform.js
+++ b/amd/src/authorform.js
@@ -269,13 +269,11 @@ define(['jquery'], function($) {
 
         // insert buttons that allow users to replace the expected output 
         // with output got from testing the answer program
-        $('<button type="button">&lt;&lt;</button>').click(
-            function() {
-                var gotPre = $(this).prev('[id^="id_got_"]');
-                var testCaseId = gotPre.attr('id').replace('id_got_', '');
-                $('#id_expected_' + testCaseId).val(gotPre.text())
-            }
-        ).insertAfter('[id^="id_got_"]')
+        $('button.replaceexpectedwithgot').click(function() {
+            var gotPre = $(this).prev('pre[id^="id_got_"]');
+            var testCaseId = gotPre.attr('id').replace('id_got_', '');
+            $('#id_expected_' + testCaseId).val(gotPre.text())
+        })
     }
 
     return {initEditForm: initEditForm};

--- a/classes/testing_outcome.php
+++ b/classes/testing_outcome.php
@@ -141,20 +141,29 @@ class qtype_coderunner_testing_outcome {
             return get_string('badquestion', 'qtype_coderunner') . html_writer::tag('pre', $this->errormessage);
         } else if (!$this->iscombinatorgrader()) {  // Combinator grader results table can't be used
             $numerrors = 0;
-            $firstfailure = '';
-            foreach ($this->testresults as $testresult) {
+            $failures = new html_table();
+            $failures->attributes['class'] = 'coderunner-test-results';
+            $failures->head = array(get_string('name'),
+                get_string('expectedcolhdr', 'qtype_coderunner'),
+                get_string('gotcolhdr', 'qtype_coderunner'));
+            $failures->data = array();
+
+            foreach ($this->testresults as $i => $testresult) {
                 if (!$testresult->iscorrect) {
                     $numerrors += 1;
-                    if ($firstfailure === '' && isset($testresult->expected) && isset($testresult->got)) {
-                        $errorhtml = $this->make_error_html($testresult->expected, $testresult->got);
-                        $firstfailure = get_string('firstfailure', 'qtype_coderunner', $errorhtml);
+                    if (isset($testresult->expected) && isset($testresult->got)) {
+                        $failures->data[] = array(
+                            html_writer::link('#id_testcode_'.$i, get_string('testcase', 'qtype_coderunner', $i+1)),
+                            html_writer::link('#id_expected_'.$i, html_writer::tag('pre', s($testresult->expected))), 
+                            html_writer::tag('pre', s($testresult->got), array('id' => 'id_got_'.$i)),
+                        );
                     }
                 }
             }
             $message = get_string('failedntests', 'qtype_coderunner', array(
                 'numerrors' => $numerrors));
-            if ($firstfailure) {
-                $message .= html_writer::empty_tag('br') . $firstfailure;
+            if ($failures->data) {
+                $message .= html_writer::table($failures) . get_string('replaceexpectedwithgot', 'qtype_coderunner');
             } else {
                 $message .= get_string('failedtesting', 'qtype_coderunner');
             }

--- a/classes/testing_outcome.php
+++ b/classes/testing_outcome.php
@@ -155,7 +155,7 @@ class qtype_coderunner_testing_outcome {
                         $failures->data[] = array(
                             html_writer::link('#id_testcode_'.$i, get_string('testcase', 'qtype_coderunner', $i+1)),
                             html_writer::link('#id_expected_'.$i, html_writer::tag('pre', s($testresult->expected))), 
-                            html_writer::tag('pre', s($testresult->got), array('id' => 'id_got_'.$i)),
+                            html_writer::tag('pre', s($testresult->got), array('id' => 'id_got_'.$i)) . html_writer::tag('button', '&lt;&lt;', array('class' => 'replaceexpectedwithgot')),
                         );
                     }
                 }

--- a/lang/en/qtype_coderunner.php
+++ b/lang/en/qtype_coderunner.php
@@ -595,3 +595,4 @@ $string['useace'] = 'Use ace';
 $string['validateonsave'] = 'Validate on save';
 
 $string['xmlcoderunnerformaterror'] = 'XML format error in coderunner question';
+$string['replaceexpectedwithgot'] = 'Click on the &lt;&lt; button to replace the expected output of this testcase with actual output.';

--- a/styles.css
+++ b/styles.css
@@ -7,6 +7,8 @@
     box-sizing: border-box;
 }
 
+#page-question-type-coderunner table.coderunner-test-results td,
+#page-question-type-coderunner table.coderunner-test-results th,
 .que.coderunner table.coderunner-test-results td,
 .que.coderunner table.coderunnerexamples td,
 .que.coderunner textarea.edit_code {


### PR DESCRIPTION
The author form will get the following changes (in relation to the validation of the answer program):
1. all failing test cases are displayed (not just the first one)
2. a button below the the got output allows the teacher to replace the expected output with the real output of the answer program
3. expected and got output are displayed top aligned (this makes it easier to compare results that have different number of output lines than expected)
4. each failing test case has a link to it (for quick access from the answer section)
5. the expected output of each failing test case has a link to it (for quick access from the answer section)