### PR TITLE
Fix privacy provider signature (fatal error)

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -26,13 +26,16 @@ namespace qtype_coderunner\privacy;
 defined('MOODLE_INTERNAL') || die();
 
 class provider implements \core_privacy\local\metadata\null_provider {
+    // This polyfill allows the provider to work on both old (pre-7) and new PHP versions.
+    use \core_privacy\local\legacy_polyfill;
+
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function get_reason() {
+    public static function _get_reason() {
         return 'privacy:metadata';
     }
 }


### PR DESCRIPTION
The privacy provider get_reason function is missing its return type ': string' - this means it causes a fatal error when run on PHP 7.x, as it must be in Moodle 3.4 or 3.5. At least on some screens this breaks the entire privacy API on the system, so it's fairly important. :)

The simplest fix is to add ':string' in the function definition, but if you want it to also work on Moodle 3.3 (the only version that supports the privacy API, but allows a PHP version less than 7) then the documentation says you need the more complicated fix using legacy polyfill, which I've done here. I have not tested this on an older version but it's what the documentation says to do so hopefully it works... 

https://docs.moodle.org/dev/Privacy_API#What_to_do_if_you_have_one_plugin_that_supports_multiple_branches

Note: To test you can run 
vendor/bin/phpunit --filter=test_all_providers_compliant privacy/tests/provider_test.php

After fix this should take a while but pass (unless you have other non-compliant plugins installed in which case there will be a failure for each one). Before fix, you get this error pretty immediately:

PHP Fatal error:  Declaration of qtype_coderunner\privacy\provider::get_reason() must be compatible
with core_privacy\local\metadata\null_provider::get_reason(): string in C:\Users\MyUsername\workspace\ou-moodle2\question\type\coderunner\classes\privacy\provider.php on line 28