### PR TITLE
Fix missing_prototype test

### DIFF
--- a/tests/behat/missing_prototype.feature
+++ b/tests/behat/missing_prototype.feature
@@ -47,6 +47,8 @@ Feature: missing_prototype
       | id_coderunnertype | python3_test_prototype            |
       | name              | Prototype tester                  |
       | id_questiontext   | Write the inevitable sqr function |
+      | id_customise      | 1                                 |
+      | id_uiplugin       | None                              |
       | id_testcode_0     | print(sqr(-11))                   |
       | id_expected_0     | 121                               |
       | id_testcode_1     | print(sqr(9))                     |


### PR DESCRIPTION
This test is failing when we try to run it, as the textarea that the first scenario tries to use is hidden (its been replaced by the ACE editor).  This fix sets the UI plugin to "none" for the question, which is the same method used by the second scenario.