### PR TITLE
Fix behat failure with Moodle 3.5.2+

### DIFF
--- a/tests/behat/export.feature
+++ b/tests/behat/export.feature
@@ -27,7 +27,7 @@ Feature: Export CodeRunner questions
     When I navigate to "Export" node in "Course administration > Question bank"
     And I set the field "id_format_xml" to "1"
     And I press "Export questions to file"
-    Then following "click here" should download between "3400" and "3900" bytes
+    Then following "click here" should download between "3400" and "4100" bytes
     # If the download step is the last in the scenario then we can sometimes run
     # into the situation where the download page causes a http redirect but behat
     # has already conducted its reset (generating an error). By putting a logout


### PR DESCRIPTION
Moodle fix MDL-63165 icreases the size of all export files, which breaks
the test I fix here.