### PR TITLE
Coderunner: Inconsistent database defaults (XMLDB Check defaults)

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -300,6 +300,19 @@ function xmldb_qtype_coderunner_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2018121002, 'qtype', 'coderunner');
     }
 
+    if ($oldversion < 2019051600) {
+
+        // Changing the default of field useace on table question_coderunner_options to 1.
+        $table = new xmldb_table('question_coderunner_options');
+        $field = new xmldb_field('useace', XMLDB_TYPE_INTEGER, '1', null, null, null, '1', 'answerpreload');
+
+        // Launch change of default for field useace.
+        $dbman->change_field_default($table, $field);
+
+        // Coderunner savepoint reached.
+        upgrade_plugin_savepoint(true, 2019051600, 'qtype', 'coderunner');
+    }
+
     require_once(__DIR__ . '/upgradelib.php');
     update_question_types();
 

--- a/version.php
+++ b/version.php
@@ -22,7 +22,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2019022600;
+$plugin->version  = 2019051600;
 $plugin->requires = 2015051200;
 $plugin->cron = 0;
 $plugin->component = 'qtype_coderunner';


### PR DESCRIPTION
Hi Richard,
The XMLDB "Check defaults" tool was run via /admin/tool/xmldb/.
The following inconsistencies were found in qtype_coderunner:
Table: question_coderunner_options. Field: useace, Expected '1' Actual -
The install.xml seemed fine. I had to update the 'useace' field in upgrade.php.

Many thanks,
Mahmoud