### PR TITLE
Fix missing `MoodleQuickForm::hideIf` method for Moodle versions < 3.4

### DIFF
--- a/edit_coderunner_form.php
+++ b/edit_coderunner_form.php
@@ -206,7 +206,9 @@ class qtype_coderunner_edit_form extends question_edit_form {
         // Unless behat is running, hide the attachments file picker.
         // behat barfs if it's hidden.
         if ($CFG->prefix !== "b_") {
-            $mform->hideIf('sampleanswerattachments', 'attachments', 'eq', 0);
+            /* @var $mform MoodleQuickForm */
+            $method = method_exists($mform, 'hideIf') ? 'hideIf' : 'disabledIf';
+            $mform->$method('sampleanswerattachments', 'attachments', 'eq', 0);
         }
         $mform->addElement('advcheckbox', 'validateonsave', null,
                 get_string('validateonsave', 'qtype_coderunner'));


### PR DESCRIPTION
MoodleQuickForm does not provide any `hideIf` method for Moodle versions < 3.4.
This fix uses the `disabledIf` method in replacement for these versions.
It does not alter the default behaviour for Moodle versions >= 3.4.

Signed-off-by: Eric Villard <dev@eviweb.fr>