### PR TITLE
fix: allow Jobe sandbox HTTPS protocol

### DIFF
--- a/classes/jobesandbox.php
+++ b/classes/jobesandbox.php
@@ -297,7 +297,8 @@ class qtype_coderunner_jobesandbox extends qtype_coderunner_sandbox {
         } else {
             $jobe = $this->jobeserver;
         }
-        $url = "http://$jobe/jobe/index.php/restapi/$resource";
+        $protocol = 'http://';
+        $url = (strpos($jobe, 'http') === 0 ? $jobe : $protocol.$jobe)."/jobe/index.php/restapi/$resource";
 
         $headers = array(
                 'User-Agent: CodeRunner',

--- a/lang/en/qtype_coderunner.php
+++ b/lang/en/qtype_coderunner.php
@@ -278,7 +278,7 @@ $string['is_prototype'] = 'Use as prototype';
 $string['jobe_apikey'] = 'Jobe API-key';
 $string['jobe_apikey_desc'] = 'The API key to be included in all REST requests to the Jobe server (if required). Max 40 chars. Leave blank to omit the API Key from requests';
 $string['jobe_host'] = 'Jobe server';
-$string['jobe_host_desc'] = 'The host name of the Jobe server plus the port number if other than port 80, e.g. jobe.somewhere.edu:4010. The URL for the Jobe request is obtained by prefixing this string with http:// and appending /jobe/index.php/restapi/<REST_METHOD>.';
+$string['jobe_host_desc'] = 'The host name of the Jobe server plus the port number if other than port 80, e.g. jobe.somewhere.edu:4010. The URL for the Jobe request is obtained by default by prefixing this string with http:// and appending /jobe/index.php/restapi/<REST_METHOD>. You may either specify the https:// protocol in front of the host name (e.g. https://jobe.somewhere.edu) if the Jobe server is set behind a reverse proxy which act as an SSL termination.';
 
 $string['language'] = 'Sandbox language';
 $string['languages'] = 'Languages';


### PR DESCRIPTION
By default the HTTP protocol of the Jobe sandbox was hardcoded.
In case the sandbox is deployed behind a reverse proxy, it's worth
letting admins the possibility to specify the HTTPS protocol.
This fix answers this issue.
Please note that the default behaviour remains unchanged.

Signed-off-by: Eric Villard <dev@eviweb.fr>