### PR TITLE
Update Behat tests to use the MDL-66821 changes

### DIFF
--- a/tests/behat/attachmentimportexport.feature
+++ b/tests/behat/attachmentimportexport.feature
@@ -23,7 +23,7 @@ Feature: Test importing and exporting of question with attachments
     And I log in as "teacher1"
     And I am on "Course 1" course homepage
     And I navigate to "Question bank" in current page administration
-    And I click on "Edit" "link" in the "Square function" "table_row"
+    And I choose "Edit question" action for "Square function" in the question bank
     And I click on "a[aria-controls='id_attachmentoptions']" "css_element"
     And I set the field "Answer" to "from sqrmodule import sqr"
     And I set the field "Validate on save" to "1"
@@ -35,9 +35,8 @@ Feature: Test importing and exporting of question with attachments
     Then I should see "Question bank"
     And I should see "Last modified by"
 
-
-@file_attachments
-Scenario: As a teacher I can export a question with an attached sample answer file
+  @file_attachments
+  Scenario: As a teacher I can export a question with an attached sample answer file
     Given I am on "Course 1" course homepage
     When I navigate to "Question bank > Export" in current page administration
     And I set the field "id_format_xml" to "1"
@@ -49,8 +48,8 @@ Scenario: As a teacher I can export a question with an attached sample answer fi
     # step we avoid behat doing the reset until we are off that page.
     And I log out
 
-@file_attachments
-Scenario: As a teacher I can import a question with an attached sample answer file
+  @file_attachments
+  Scenario: As a teacher I can import a question with an attached sample answer file
     Given I am on "Course 1" course homepage
     When I navigate to "Question bank > Import" in current page administration
     And I set the field "id_format_xml" to "1"
@@ -60,7 +59,7 @@ Scenario: As a teacher I can import a question with an attached sample answer fi
     And I should see "Importing 1 questions from file"
     And I press "Continue"
     And I should see "Python3 sqr function with an attachment"
-    And I click on "Edit" "link" in the "Python3 sqr function with an attachment" "table_row"
+    And I choose "Edit question" action for "Python3 sqr function with an attachment" in the question bank
     And I press "id_submitbutton"
     # Sample question has validate on save set, so should be checked on save
     Then I should see "Question bank"

--- a/tests/behat/attachments.feature
+++ b/tests/behat/attachments.feature
@@ -23,7 +23,7 @@ Feature: Test editing and using attachments to a CodeRunner question
     And I log in as "teacher1"
     And I am on "Course 1" course homepage
     And I navigate to "Question bank" in current page administration
-    And I click on "Edit" "link" in the "Square function" "table_row"
+    And I choose "Edit question" action for "Square function" in the question bank
     And I click on "a[aria-controls='id_attachmentoptions']" "css_element"
     And I set the field "Answer" to "from sqrmodule import sqr"
     And I set the field "Validate on save" to "1"
@@ -41,17 +41,17 @@ Feature: Test editing and using attachments to a CodeRunner question
     Then I should see "Question bank"
     And I should see "Last modified by"
 
-@javascript @file_attachments
-Scenario: As a teacher I can preview my question but get an error without attachment.
-    When I click on "Preview" "link" in the "Square function" "table_row"
+  @javascript @file_attachments
+  Scenario: As a teacher I can preview my question but get an error without attachment.
+    When I choose "Preview" action for "Square function" in the question bank
     And I switch to "questionpreview" window
     And I set the field "Answer" to "from sqrmodule import sqr"
     And I press "Check"
     Then I should see "Not enough attachments, 1 required."
 
-@javascript @file_attachments
-Scenario: As a teacher I can preview my question and get it right with an attachment
-    When I click on "Preview" "link" in the "Square function" "table_row"
+  @javascript @file_attachments
+  Scenario: As a teacher I can preview my question and get it right with an attachment
+    When I choose "Preview" action for "Square function" in the question bank
     And I switch to "questionpreview" window
     And I upload "question/type/coderunner/tests/fixtures/sqrmodule.py" file to "" filemanager
     And I set the field "Answer" to "from sqrmodule import sqr"

--- a/tests/behat/backup_and_restore.feature
+++ b/tests/behat/backup_and_restore.feature
@@ -29,7 +29,7 @@ Feature: Duplicate a course containing a CodeRunner question
     And I restore "test_backup.mbz" backup into a new course using this options:
       | Schema | Course name | Course 2 |
     And I navigate to "Question bank" in current page administration
-    And I click on "Edit" "link" in the "Square function" "table_row"
+    And I choose "Edit question" action for "Square function" in the question bank
     Then the following fields match these values:
       | Question name                  | Square function                                 |
       | Question text                  | Write a function sqr(n) that returns n squared. |

--- a/tests/behat/check_graph_question_types.feature
+++ b/tests/behat/check_graph_question_types.feature
@@ -31,7 +31,7 @@ Feature: Check that the directed and undirected graph question types work.
       | id_expected_0     | [('A', [('B', 'wt')]), ('B', [])]   |
       | id_answer         | {"edgeGeometry":[{"lineAngleAdjust":0,"parallelPart":0.5,"perpendicularPart":0}],"nodeGeometry":[[246,163],[426,160]],"nodes":[["A",false],["B",false]],"edges":[[0,1,"wt"]]}|
     And I enable UI plugins
-    And I click on "Preview" "link" in the "Test 2-node directed graph" "table_row"
+    And I choose "Preview" action for "Test 2-node directed graph" in the question bank
     And I switch to "questionpreview" window
     Then I should see a canvas
     And I press "Fill in correct responses"
@@ -48,7 +48,7 @@ Feature: Check that the directed and undirected graph question types work.
       | id_expected_0     | [('A', [('B', 'wt')]), ('B', [('A', 'wt')])] |
       | id_answer         | {"edgeGeometry":[{"lineAngleAdjust":0,"parallelPart":0.5,"perpendicularPart":0}],"nodeGeometry":[[246,163],[426,160]],"nodes":[["A",false],["B",false]],"edges":[[0,1,"wt"]]}|
     And I enable UI plugins
-    And I click on "Preview" "link" in the "Test 2-node undirected graph" "table_row"
+    And I choose "Preview" action for "Test 2-node undirected graph" in the question bank
     And I switch to "questionpreview" window
     And I press "Fill in correct responses"
     And I press "Check"

--- a/tests/behat/check_twig_student_variable.feature
+++ b/tests/behat/check_twig_student_variable.feature
@@ -4,7 +4,7 @@ Feature: Check the STUDENT Twig variable allows access to current username in Co
   As a teacher
   I should be able to write a function that prints my username it should be marked right
 
-Background:
+  Background:
     Given the following "users" exist:
       | username | firstname | lastname | email            |
       | teacher1 | Teacher   | 1        | teacher1@asd.com |
@@ -20,7 +20,6 @@ Background:
     And I log in as "teacher1"
     And I am on "Course 1" course homepage
     And I navigate to "Question bank" in current page administration
-    And I disable UI plugins
     And I add a "CodeRunner" question filling the form with:
       | id_coderunnertype       | python3                                    |
       | id_customise            | 1                                          |
@@ -34,7 +33,7 @@ Background:
       | id_expected_0           | True                                       |
 
   Scenario: Preview the STUDENT variable function question and check it is marked right in CodeRunner
-    When I click on "Preview" "link" in the "STUDENT variable" "table_row"
+    When I choose "Preview" action for "STUDENT variable" in the question bank
     And I switch to "questionpreview" window
     And I set the field with xpath "//textarea[contains(@name, 'answer')]" to "blah blah blah"
     And I press "Check"

--- a/tests/behat/create_python3_sqr_function.feature
+++ b/tests/behat/create_python3_sqr_function.feature
@@ -40,7 +40,7 @@ Feature: Create a CodeRunner question (the sqr function example)
     And I should not see "Write a sqr function"
     And I should see "sqr acceptance question"
 
-    When I click on "Edit" "link" in the "sqr acceptance question" "table_row"
+    When I choose "Edit question" action for "sqr acceptance question" in the question bank
     And I set the field "id_customise" to "1"
     And I set the field "id_iscombinatortemplate" to "1"
 

--- a/tests/behat/edit.feature
+++ b/tests/behat/edit.feature
@@ -25,7 +25,7 @@ Feature: Test editing a CodeRunner question
     And I navigate to "Question bank" in current page administration
 
   Scenario: Edit a CodeRunner question
-    When I click on "Edit" "link" in the "Square function" "table_row"
+    When I choose "Edit question" action for "Square function" in the question bank
     And I set the following fields to these values:
       | Question name | |
     And I press "Save changes"

--- a/tests/behat/edit_table.feature
+++ b/tests/behat/edit_table.feature
@@ -26,7 +26,7 @@ Feature: Test editing a CodeRunner question using the Table UI
 
 
   Scenario: Edit a CodeRunner printans question into a table question
-    When I click on "Edit" "link" in the "Print answer" "table_row"
+    When I choose "Edit question" action for "Print answer" in the question bank
     And I set the following fields to these values:
       | customise      | 1                             |
       | id_template    | print('{{ STUDENT_ANSWER }}') |

--- a/tests/behat/gapfiller_ui.feature
+++ b/tests/behat/gapfiller_ui.feature
@@ -24,9 +24,8 @@ Feature: Test the GapFiller_UI
     And I am on "Course 1" course homepage
     And I navigate to "Question bank" in current page administration
 
-
   Scenario: Edit a CodeRunner printans question into a gap-filler question
-    When I click on "Edit" "link" in the "Print answer" "table_row"
+    When I choose "Edit question" action for "Print answer" in the question bank
     And I set the following fields to these values:
       | customise      | 1                             |
       | id_template    | print('{{ STUDENT_ANSWER }}') |
@@ -50,7 +49,7 @@ Feature: Test the GapFiller_UI
     And I should see "Created by"
     And I should see "Last modified by"
 
-    When I click on "Edit" "link" in the "Print answer" "table_row"
+    When I choose "Edit question" action for "Print answer" in the question bank
     And I set the field "id_globalextra" to:
      """
      I'm a line of text
@@ -83,7 +82,7 @@ for element in answer: print(element)
     And I should see "Created by"
     And I should see "Last modified by"
 
-    When I click on "Preview" "link" in the "Print answer" "table_row"
+    When I choose "Preview" action for "Print answer" in the question bank
     And I switch to "questionpreview" window
     And I set the field "cr_gapfiller_field" to:
      """

--- a/tests/behat/grading_scenarios.feature
+++ b/tests/behat/grading_scenarios.feature
@@ -26,7 +26,7 @@ Feature: Check grading with the Python 3 sqr function CodeRunner question
     And I disable UI plugins
 
   Scenario: Preview the Python3 sqr function CodeRunner question submit two different wrong answers then the right answer
-    When I click on "Preview" "link" in the "Square function" "table_row"
+    When I choose "Preview" action for "Square function" in the question bank
     And I switch to "questionpreview" window
     And I set the field with xpath "//textarea[contains(@name, 'answer')]" to "def sqr(n): return n"
     And I press "Check"
@@ -38,7 +38,7 @@ Feature: Check grading with the Python 3 sqr function CodeRunner question
     And I should see "Mark 24.80 out of 31.00"
 
   Scenario: Preview the Python3 sqr function CodeRunner question submit the same wrong answer twice then the right answer
-    When I click on "Preview" "link" in the "Square function" "table_row"
+    When I choose "Preview" action for "Square function" in the question bank
     And I switch to "questionpreview" window
     And I set the field with xpath "//textarea[contains(@name, 'answer')]" to "def sqr(n): return n"
     And I press "Check"
@@ -49,7 +49,7 @@ Feature: Check grading with the Python 3 sqr function CodeRunner question
     And I should see "Mark 27.90 out of 31.00"
 
   Scenario: Preview the Python3 sqr function CodeRunner question precheck, submit the same wrong answer twice, fix, precheck then check
-    When I click on "Preview" "link" in the "Square function" "table_row"
+    When I choose "Preview" action for "Square function" in the question bank
     And I switch to "questionpreview" window
     And I set the field with xpath "//textarea[contains(@name, 'answer')]" to "def sqr(n): return n"
     And I press "Precheck"
@@ -61,7 +61,7 @@ Feature: Check grading with the Python 3 sqr function CodeRunner question
     And I should see "Mark 27.90 out of 31.00"
 
   Scenario: Preview the Python3 sqr function CodeRunner question precheck, submit the same wrong answer twice, fix, then check
-    When I click on "Preview" "link" in the "Square function" "table_row"
+    When I choose "Preview" action for "Square function" in the question bank
     And I switch to "questionpreview" window
     And I set the field with xpath "//textarea[contains(@name, 'answer')]" to "def sqr(n): return n"
     And I press "Precheck"
@@ -72,7 +72,7 @@ Feature: Check grading with the Python 3 sqr function CodeRunner question
     And I should see "Mark 27.90 out of 31.00"
 
   Scenario: Preview the Python3 sqr function CodeRunner question precheck a wrong answer then close and submit
-    When I click on "Preview" "link" in the "Square function" "table_row"
+    When I choose "Preview" action for "Square function" in the question bank
     And I switch to "questionpreview" window
     And I set the field with xpath "//textarea[contains(@name, 'answer')]" to "def sqr(n): return 0"
     And I press "Precheck"

--- a/tests/behat/import.feature
+++ b/tests/behat/import.feature
@@ -43,7 +43,7 @@ Feature: Import CodeRunner questions
     And I should see "15. Draw a graph with two nodes A and B"
     And I press "Continue"
     And I should see "C function: sqr"
-    And I click on "Edit" "link" in the "Java Class: bod" "table_row"
+    And I choose "Edit question" action for "Java Class: bod" in the question bank
     And I set the field "id_customise" to "1"
     And I set the field "id_useace" to "0"
     And I should see "public class __tester__ {" in the "id_template" "field"

--- a/tests/behat/make_combinator_prototype.feature
+++ b/tests/behat/make_combinator_prototype.feature
@@ -56,9 +56,7 @@ Feature: make_combinator_prototype
       | id_expected_1     | 81                                |
 
   Scenario: As a teacher, I get marked right (using combinator template) if I submit a correct answer to a CodeRunner question
-    # HACK ALERT: following line selects row 0 because question name (Combinator prototype tester)
-    # comes before the prototype.
-    When I click on "table#categoryquestions tr.r0 a[title='Preview']" "css_element"
+    When I choose "Preview" action for "Combinator prototype tester" in the question bank
     And I switch to "questionpreview" window
     And I set the field "id_behaviour" to "Adaptive mode"
     And I press "Start again with these options"

--- a/tests/behat/make_prototype.feature
+++ b/tests/behat/make_prototype.feature
@@ -52,9 +52,7 @@ Feature: make_prototype
       | id_expected_1     | 81                                |
 
   Scenario: As a teacher, I get marked right (using per-test-case template) if I submit a correct answer to a CodeRunner question
-    # HACK ALERT: following line selects row 1 because question name (Prototype tester)
-    # comes after the prototype on row 0.
-    And I click on "table#categoryquestions tr.r0 a[title='Preview']" "css_element"
+    When I choose "Preview" action for "Prototype tester" in the question bank
     And I switch to "questionpreview" window
     And I set the field "id_behaviour" to "Adaptive mode"
     And I press "Start again with these options"

--- a/tests/behat/missing_prototype.feature
+++ b/tests/behat/missing_prototype.feature
@@ -62,7 +62,8 @@ Feature: missing_prototype
   Scenario: As a teacher, if I preview a question with a missing prototype I should see a missing prototype error
     Given I am on "Course 1" course homepage
     And I navigate to "Question bank" in current page administration
-    And I click on "table#categoryquestions a[title='Preview']" "css_element"
+
+    When I choose "Preview" action for "Prototype tester" in the question bank
     And I switch to "questionpreview" window
     And I set the field "id_behaviour" to "Adaptive mode"
     And I press "Start again with these options"
@@ -73,7 +74,7 @@ Feature: missing_prototype
   Scenario: As a teacher, I should be able to re-parent the question and have it work correctly
     Given I am on "Course 1" course homepage
     And I navigate to "Question bank" in current page administration
-    And I click on "table#categoryquestions a[title='Edit']" "css_element"
+    When I choose "Edit question" action for "Prototype tester" in the question bank
     Then I should see "This question was defined to be of type 'python3_test_prototype' but the prototype does not exist, or is non-unique, or is unavailable in this context"
     And I set the field "id_coderunnertype" to "python3"
     And I set the field "id_customise" to "1"

--- a/tests/behat/reset_button.feature
+++ b/tests/behat/reset_button.feature
@@ -25,7 +25,7 @@ Feature: Preview the Python 3 sqr function CodeRunner question with a preload
     And I navigate to "Question bank" in current page administration
 
   Scenario: Preview the Python3 sqr function, get it wrong, then reset it
-    When I click on "Preview" "link" in the "Square function" "table_row"
+    When I choose "Preview" action for "Square function" in the question bank
     And I switch to "questionpreview" window
     And I should see "# Your answer goes here"
     And I set the field with xpath "//textarea[contains(@name, 'answer')]" to "def sqr(n): return n"

--- a/tests/behat/run_python3_sqr_function.feature
+++ b/tests/behat/run_python3_sqr_function.feature
@@ -25,7 +25,7 @@ Feature: Preview the Python 3 sqr function CodeRunner question
     And I navigate to "Question bank" in current page administration
 
   Scenario: Preview the Python3 sqr function CodeRunner question and get it right
-    When I click on "Preview" "link" in the "Square function" "table_row"
+    When I choose "Preview" action for "Square function" in the question bank
     And I switch to "questionpreview" window
     And I set the field with xpath "//textarea[contains(@name, 'answer')]" to "def sqr(n): return n * n"
     And I press "Check"
@@ -40,14 +40,14 @@ Feature: Preview the Python 3 sqr function CodeRunner question
     And I should see "Marks for this submission: 31.00/31.00"
 
   Scenario: Preview the Python3 sqr function CodeRunner question and submit syntactically invalid answer
-    When I click on "Preview" "link" in the "Square function" "table_row"
+    When I choose "Preview" action for "Square function" in the question bank
     And I switch to "questionpreview" window
     And I set the field with xpath "//textarea[contains(@name, 'answer')]" to "def sqr(n); return n * n"
     And I press "Check"
     And I should see "Marks for this submission: 0.00/31.00"
 
   Scenario: Preview the Python3 sqr function CodeRunner question and get it wrong
-    When I click on "Preview" "link" in the "Square function" "table_row"
+    When I choose "Preview" action for "Square function" in the question bank
     And I switch to "questionpreview" window
     And I set the field with xpath "//textarea[contains(@name, 'answer')]" to "def sqr(n): return n * n * n"
     And I press "Check"

--- a/tests/behat/run_python3_sqr_function_templated.feature
+++ b/tests/behat/run_python3_sqr_function_templated.feature
@@ -33,7 +33,7 @@ Feature: Combinator template is called test-by-test if a runtime error occurs wh
       | id_testcode_2     | sqr(-3)                 |
       | id_expected_2     | 9                       |
       | id_display_2      | Hide                    |
-    When I click on "Edit" "link" in the "sqr acceptance question" "table_row"
+    When I choose "Edit question" action for "sqr acceptance question" in the question bank
     And I set the field "id_customise" to "1"
     And I set the field "id_iscombinatortemplate" to "1"
 
@@ -52,7 +52,7 @@ Feature: Combinator template is called test-by-test if a runtime error occurs wh
     And I press "id_submitbutton"
 
   Scenario: As a teacher, I get marked right if I submit a correct answer to a CodeRunner question
-    When I click on "Preview" "link" in the "sqr acceptance question" "table_row"
+    When I choose "Preview" action for "sqr acceptance question" in the question bank
     And I switch to "questionpreview" window
     And I set the field with xpath "//textarea[contains(@name, 'answer')]" to "def sqr(n): return n * n"
     And I press "Check"
@@ -68,7 +68,7 @@ Feature: Combinator template is called test-by-test if a runtime error occurs wh
     And I should see "Marks for this submission: 1.00/1.00"
 
   Scenario: As a teacher previewing a CodeRunner question, I should see all tests up to one that gives a runtime error then no more
-    When I click on "Preview" "link" in the "sqr acceptance question" "table_row"
+    When I choose "Preview" action for "sqr acceptance question" in the question bank
     And I switch to "questionpreview" window
     And I set the field with xpath "//textarea[contains(@name, 'answer')]" to "def sqr(n): return n * n if n != 11 else n[-1]"
     And I press "Check"

--- a/tests/behat/set_uiplugin.feature
+++ b/tests/behat/set_uiplugin.feature
@@ -26,28 +26,28 @@ Feature: Check that a selected UI plugin is saved
     And I enable UI plugins
 
   Scenario: Selecting the Graph UI plugin results in a canvas being displayed
-    When I click on "Edit" "link" in the "Square function" "table_row"
+    When I choose "Edit question" action for "Square function" in the question bank
     And I set the following fields to these values:
       | id_customise | 1     |
       | id_uiplugin  | graph |
     Then I should see a canvas
 
   Scenario: UI plugin state is saved when question is saved
-    When I click on "Edit" "link" in the "Square function" "table_row"
+    When I choose "Edit question" action for "Square function" in the question bank
     And I click on "a[aria-controls='id_answerhdr']" "css_element"
     And I set the following fields to these values:
       | id_customise | 1     |
       | id_uiplugin  | graph |
     And I press "id_submitbutton"
-    And I click on "Edit" "link" in the "Square function" "table_row"
+    When I choose "Edit question" action for "Square function" in the question bank
     Then I should see a canvas
 
 Scenario: UI plugin state is saved for student
-When I click on "Edit" "link" in the "Square function" "table_row"
+  When I choose "Edit question" action for "Square function" in the question bank
     And I set the following fields to these values:
       | id_customise | 1     |
       | id_uiplugin  | graph |
     And I press "id_submitbutton"
-    When I click on "Preview" "link" in the "Square function" "table_row"
+  When I choose "Preview" action for "Square function" in the question bank
     And I switch to "questionpreview" window
     Then I should see a canvas

--- a/tests/behat/showdifferences_button.feature
+++ b/tests/behat/showdifferences_button.feature
@@ -25,7 +25,7 @@ Feature: Show differences in CodeRunner questions
     And I navigate to "Question bank" in current page administration
 
   Scenario: As a teacher submitting a wrong answer to a CodeRunner question preview, the Show differences button should work
-    When I click on "Preview" "link" in the "Square function" "table_row"
+    When I choose "Preview" action for "Square function" in the question bank
     And I switch to "questionpreview" window
     And I set the field with xpath "//textarea[contains(@name, 'answer')]" to "def sqr(n): return n * n if n != -7 else 12345"
     And I press "Check"
@@ -48,7 +48,7 @@ Feature: Show differences in CodeRunner questions
     And I should not see highlighted "5"
 
   Scenario: As a teacher submitting a wrong answer to a CodeRunner question preview and only hidden tests fail, I should not see the Show differences button
-    When I click on "a[title='Preview']" "css_element"
+    When I choose "Preview" action for "Square function" in the question bank
     And I switch to "questionpreview" window
     And I set the field "id_behaviour" to "Adaptive mode"
     And I press "Start again with these options"


### PR DESCRIPTION
Hi Richard.

At the point where you start using Moodle 3.8, you will need these changes, or all your Behat tests will start to fail.

And, as soon as you are using 3.7.3 or 3.6.7 for development it will be safe to incorporate these changes.

The explantion is here: https://github.com/moodle/moodle/blob/e04a73ccc06e18d8d3b3661f8f9bc16911747830/question/type/upgrade.txt#L5. I am afraid it is all my fault, but a necessary evil.