### PR TITLE
Improve get_main_class so main method can have any legal modifiers

### DIFF
--- a/classes/jobesandbox.php
+++ b/classes/jobesandbox.php
@@ -227,7 +227,7 @@ class qtype_coderunner_jobesandbox extends qtype_coderunner_sandbox {
     // Not totally safe as it doesn't parse the file, e.g. would be fooled
     // by a commented-out main class with a different name.
     private function get_main_class($prog) {
-        $pattern = '/(^|\W)public\s+class\s+(\w+)[^{]*\{.*?public\s+static\s+void\s+main\s*\(\s*String/ms';
+        $pattern = '/(^|\W)public\s+class\s+(\w+)[^{]*\{.*?((public\s([a-z]*\s)*static)|(static\s([a-z]*\s)*public))\s([a-z]*\s)*void\s+main\s*\(\s*String/ms';
         if (preg_match_all($pattern, $prog, $matches) !== 1) {
             return false;
         } else {


### PR DESCRIPTION
Fixes `prog.java:1: error: class Main is public, should be declared in a file named Main.java
public class Main {
       ^
1 error` being printed on valid java programs such as:
```
public class Main {
    // public and static modifiers in unusual order
    static public void main(String[] args) {}
}
```
or even:
```
public class Main {
    strictfp static final public synchronized void main(String[] args) {}
}
```

The get_main_class assumed the main method will always appear with tokens `public static void main`  in this order. This update allows for other modifiers and doesn't care about their order. Public and static are still required.