### PR TITLE
Confirmation output from the previous attempt

### DIFF
--- a/classes/combinator_grader_outcome.php
+++ b/classes/combinator_grader_outcome.php
@@ -32,7 +32,7 @@ class qtype_coderunner_combinator_grader_outcome extends qtype_coderunner_testin
     // A list of the allowed attributes in the combinator template grader return value.
     public $allowedfields = array('fraction', 'prologuehtml', 'testresults', 'epiloguehtml',
                     'feedbackhtml', 'columnformats', 'showdifferences',
-                    'showoutputonly'
+                    'showoutputonly', 'attemptconfirmhtml'
         );
 
     public function __construct($isprecheck) {
@@ -40,6 +40,7 @@ class qtype_coderunner_combinator_grader_outcome extends qtype_coderunner_testin
         $this->actualmark = 0;
         $this->epiloguehtml = null;
         $this->prologuehtml = null;
+	$this->attemptconfirmhtml = null;
         $this->testresults = null;
         $this->columnformats = null;
         $this->outputonly = false;
@@ -200,6 +201,10 @@ class qtype_coderunner_combinator_grader_outcome extends qtype_coderunner_testin
                $this->showdifferences &&  isset($this->testresults);
     }
 
+    public function get_attempt_confirm() {
+        return empty($this->attemptconfirmhtml) ?
+	       '' : $this->attemptconfirmhtml;
+    }
 
     // Check that if a columnformats field is supplied
     // the number of entries is correct and that each entry is either '%s'

--- a/classes/testing_outcome.php
+++ b/classes/testing_outcome.php
@@ -416,6 +416,10 @@ class qtype_coderunner_testing_outcome {
         return '';
     }
 
+    public function get_attempt_confirm() {
+        return '';
+    }
+
     public function get_sourcecode_list() {
         return $this->sourcecodelist;
     }

--- a/renderer.php
+++ b/renderer.php
@@ -209,6 +209,15 @@ class qtype_coderunner_renderer extends qtype_renderer {
             $PAGE->requires->js_call_amd('qtype_coderunner/textareas', 'initQuestionTA', array($responsefieldid));
         }
 
+	// with the isoutputonly option, give feedback on the answer status here?
+	$toserialised = $qa->get_last_qt_var('_testoutcome');
+	if ($toserialised) {
+	    $outcome = unserialize($toserialised);
+	    if ($outcome !== false) {
+	         $qtext .= $outcome->get_attempt_confirm();
+            }
+	}
+
         return $qtext;
     }
 


### PR DESCRIPTION
I tried to slightly re-purpose the coderunner question type to applications for control theory, and possibly more general to applications where students supply the answer in Python variables. 

The question template and support code is on a separate project:

https://github.com/repagh/practicon.git 

I worked with the suggestion as given in https://coderunner.org.nz/mod/forum/discuss.php?d=309
but was not very happy with the result. In the end I forked the repository, and worked initially on using the `showoutputonly` option, but since that only works in the question feedback, and thus was tied to showing the same feedback during attempts and after completion, I changed course and added a new variable to the template output, named `attemptconfirmhtml`. If available, it is added to the question presentation. In the practicon template I use it to give confirmation on the answer variables the user has supplied. 

I hope you consider this a worthwile and sufficiently general extension to coderunner.