### PR TITLE
Moodle-plugin-ci github actions configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,134 @@
+name: Moodle plugin CI
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: 'ubuntu-latest'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: '7.4'
+            moodle-branch: 'MOODLE_311_STABLE'
+            database: 'pgsql'
+          - php: '7.3'
+            moodle-branch: 'MOODLE_310_STABLE'
+            database: 'mariadb'
+          - php: '7.2'
+            moodle-branch: 'MOODLE_39_STABLE'
+            database: 'pgsql'
+
+    services:
+      postgres:
+        image: postgres:10
+        env:
+          POSTGRES_USER: 'postgres'
+          POSTGRES_HOST_AUTH_METHOD: 'trust'
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
+
+      mariadb:
+        image: mariadb:10.5
+        env:
+          MYSQL_USER: 'root'
+          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 3
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: plugin
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mbstring, pgsql, mysqli
+          ini-values: max_input_vars=5000
+          coverage: none
+
+      - name: Initialise moodle-plugin-ci
+        run: |
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
+          # Add dirs to $PATH
+          echo $(cd ci/bin; pwd) >> $GITHUB_PATH
+          echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
+          # PHPUnit depends on en_AU.UTF-8 locale
+          sudo locale-gen en_AU.UTF-8
+          echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
+
+      - name: Start JobeInABox
+        run: sudo docker run -d -p 4000:80 --name jobe trampgeek/jobeinabox:latest
+
+      - name: Test JobeInABox
+        run: |
+          curl http://localhost:4000/jobe/index.php/restapi/languages
+          curl http://localhost:4000/jobe/index.php/restapi/runs -H 'Content-Type: application/json; charset=utf-8' --data-binary '{"run_spec":{"language_id":"python3","sourcecode":"print(\"Hello sandbox!\")","sourcefilename":"__tester__.python3","input":"","file_list":[]}}'
+
+      - name: Create Test sandbox configuration
+        run: |
+          echo "<?php"                                                          >  plugin/tests/fixtures/test-sandbox-config.php
+          echo "set_config('jobesandbox_enabled', 1, 'qtype_coderunner');"      >> plugin/tests/fixtures/test-sandbox-config.php
+          echo "set_config('jobe_host', 'localhost:4000', 'qtype_coderunner');" >> plugin/tests/fixtures/test-sandbox-config.php
+          # Display it, at least for now, so it is east to check.
+          cat plugin/tests/fixtures/test-sandbox-config.php
+
+      - name: Install Moodle
+        run: |
+          moodle-plugin-ci add-plugin trampgeek/moodle-qbehaviour_adaptive_adapted_for_coderunner
+          moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
+          moodle-plugin-ci add-config 'define("QTYPE_CODERUNNER_JOBE_HOST", "localhost:4000");'
+        env:
+          DB: ${{ matrix.database }}
+          MOODLE_BRANCH: ${{ matrix.moodle-branch }}
+
+      - name: PHP Lint
+        if: ${{ always() }}
+        run: moodle-plugin-ci phplint
+
+      - name: PHP Copy/Paste Detector
+        continue-on-error: true # This step will show errors but will not fail
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpcpd
+
+      - name: PHP Mess Detector
+        continue-on-error: true # This step will show errors but will not fail
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpmd
+
+      - name: Moodle Code Checker
+        if: ${{ always() }}
+        run: moodle-plugin-ci codechecker --max-warnings 0
+
+      - name: Moodle PHPDoc Checker
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpdoc
+
+      - name: Validating
+        if: ${{ always() }}
+        run: moodle-plugin-ci validate
+
+      - name: Check upgrade savepoints
+        if: ${{ always() }}
+        run: moodle-plugin-ci savepoints
+
+      - name: Mustache Lint
+        if: ${{ always() }}
+        run: moodle-plugin-ci mustache
+
+      - name: Grunt
+        if: ${{ always() }}
+        run: moodle-plugin-ci grunt
+
+      - name: PHPUnit tests
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpunit
+
+      - name: Behat features
+        if: ${{ always() }}
+        run: moodle-plugin-ci behat


### PR DESCRIPTION
Hi Richard, I am not sure if this is something you want, but thanks mainly to JobeInABox, I was able to get moodle-plugin-ci working for CodeRunner.

There is background on this at https://moodlehq.github.io/moodle-plugin-ci/, and if you care to look, you will see that what I have had to do is just some small additions to the standard template.

Typical results look like this: https://github.com/timhunt/moodle-qtype_coderunner/runs/3883887825?check_suite_focus=true, and as you can see a number of the code style checks are failing at the moment. Your call on whether you want to fix all those. If not, if you look in the config file, you can see how some other tests are set to report the results, but not fail the build.

Don't worry too much about Behat (I think). I think that is a false-positive caused by recent versions of Chrome.

Happy to answer questions on this.

[There is the reason I did this now, which is because the tests were failing for my on our setup. I decided to get them running on githut for a second opinion - which proved it must be something on our setup. I'll post about that in the forums.]