### PR TITLE
Add an option to have a 'Stop and read feedback' button

### DIFF
--- a/classes/constants.php
+++ b/classes/constants.php
@@ -44,6 +44,10 @@ class constants {
     const FEEDBACK_SHOW = 1;
     const FEEDBACK_HIDE = 2;
 
+    const GIVEUP_NEVER = 0;
+    const GIVEUP_AFTER_MAX_MARKS = 1;
+    const GIVEUP_ALWAYS = 2;
+
     const MAX_STRING_LENGTH = 8000;  // Maximum length of a string for display in the result table.
     const MAX_LINE_LENGTH = 100;     // Maximum length of a string for display in the result table.
     const MAX_NUM_LINES = 200;       // Maximum number of lines of text to be displayed a result table cell.

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="question/type/coderunner/db" VERSION="20210122" COMMENT="XMLDB file for Moodle question/type/coderunner"
+<XMLDB PATH="question/type/coderunner/db" VERSION="20211011" COMMENT="XMLDB file for Moodle question/type/coderunner"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../../lib/xmldb/xmldb.xsd"
 >
@@ -51,6 +51,7 @@
         <FIELD NAME="filenamesregex" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="What attachment file type a student is allowed to include with their response. * or empty means unlimited."/>
         <FIELD NAME="filenamesexplain" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Explain what file names are allowed"/>
         <FIELD NAME="displayfeedback" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="0 to allow display of specific feedback to be controlled by quiz, 1 to force display, 2 to force hide"/>
+        <FIELD NAME="giveupallowed" TYPE="int" LENGTH="4" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="When enabled, students see a button to stop interacting with the question, and instead see the general feedback. 0 = Off. 1 = button shows once best possible score cannot be improved. 2 = Always available."/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -403,7 +403,22 @@ function xmldb_qtype_coderunner_upgrade($oldversion) {
         // Coderunner savepoint reached.
         upgrade_plugin_savepoint(true, 2021012200, 'qtype', 'coderunner');
     }
-    
+
+    if ($oldversion < 2021111000) {
+
+        // Define field giveupallowed to be added to question_coderunner_options.
+        $table = new xmldb_table('question_coderunner_options');
+        $field = new xmldb_field('giveupallowed', XMLDB_TYPE_INTEGER, '4', null, XMLDB_NOTNULL, null, '0', 'displayfeedback');
+
+        // Conditionally launch add field giveupallowed.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Coderunner savepoint reached.
+        upgrade_plugin_savepoint(true, 2021111000, 'qtype', 'coderunner');
+    }
+
     require_once(__DIR__ . '/upgradelib.php');
     update_question_types();
 

--- a/edit_coderunner_form.php
+++ b/edit_coderunner_form.php
@@ -533,6 +533,20 @@ class qtype_coderunner_edit_form extends question_edit_form {
                 get_string('submitbuttons', 'qtype_coderunner'), $precheckelements, null, false);
         $mform->addHelpButton('coderunner_precheck_group', 'precheck', 'qtype_coderunner');
 
+        // Whether to show the 'Stop and read feedback' button.
+        $giveupelements = [];
+        $giveupvalues = array(
+                constants::GIVEUP_NEVER => get_string('giveup_never', 'qtype_coderunner'),
+                constants::GIVEUP_AFTER_MAX_MARKS => get_string('giveup_aftermaxmarks', 'qtype_coderunner'),
+                constants::GIVEUP_ALWAYS => get_string('giveup_always', 'qtype_coderunner'),
+        );
+
+        $giveupelements[] = $mform->createElement('select', 'giveupallowed', null, $giveupvalues);
+        $mform->addElement('group', 'coderunner_giveup_group',
+                get_string('giveup', 'qtype_coderunner'), $giveupelements, null, false);
+        $mform->addHelpButton('coderunner_giveup_group', 'giveup', 'qtype_coderunner');
+        $mform->setDefault('giveupallowed', constants::GIVEUP_NEVER);
+
         // Feedback control (a group with only one element).
         $feedbackelements = array();
         $feedbackvalues = array(

--- a/lang/en/qtype_coderunner.php
+++ b/lang/en/qtype_coderunner.php
@@ -187,6 +187,14 @@ $string['gapfillerui_delimiters_descr'] = 'A 2-character array of the strings us
 $string['gapfillerui_ui_source_descr'] = '"globalextra" to take the HTML to display from the globalextra field or "test0" to take it from the testcode field of the first test';
 $string['gapfillerui_sync_interval_secs_descr'] = 'The time interval in seconds between calls to sync the UI contents back to the question answer. 0 for no such auto-syncing.';
 
+$string['giveup'] = 'Stop button';
+$string['giveup_aftermaxmarks'] = 'Available once mark cannot be improved';
+$string['giveup_always'] = 'Always available';
+$string['giveup_help'] = 'If this option is enabled, students will see a button to stop interacting with the question, and instead display the general feedback.
+
+The \'Stop and read final feedback\' can be shown from the start, or only once the student can no longer improve their mark, due to the penalty regime.';
+$string['giveup_never'] = 'Never available';
+
 $string['globalextra'] = 'Global extra';
 $string['globalextra_help'] = 'A field of text for general-purpose use by template authors, like the extra field of each test case, but global to all tests. Available to the template author as {{ QUESTION.globalextra }}.';
 $string['graphhelp'] = '- Double click at a blank space to create a new node/state.

--- a/questiontype.php
+++ b/questiontype.php
@@ -121,7 +121,8 @@ class qtype_coderunner extends question_type {
             'maxfilesize',
             'filenamesregex',
             'filenamesexplain',
-            'displayfeedback'
+            'displayfeedback',
+            'giveupallowed',
         );
     }
 
@@ -157,8 +158,9 @@ class qtype_coderunner extends question_type {
             'maxfilesize',
             'filenamesregex',
             'filenamesexplain',
-            'displayfeedback'
-            );
+            'displayfeedback',
+            'giveupallowed',
+        );
     }
 
     public function response_file_areas() {
@@ -743,7 +745,8 @@ class qtype_coderunner extends question_type {
             'templateparamsevald' => null,
             'uiparameters' => null,
             'hidecheck' => 0,
-            'attachments' => 0
+            'attachments' => 0,
+            'giveupallowed' => 0,
         );
 
         foreach ($extraquestionfields as $field) {

--- a/tests/graphui_save_test.php
+++ b/tests/graphui_save_test.php
@@ -73,7 +73,8 @@ class qtype_coderunner_graphui_save_test extends qtype_coderunner_testcase {
 
         foreach ($questiondata->options as $optionname => $value) {
             if ($optionname != 'testcases') {
-                $this->assertEquals($value, $actualquestiondata->options->$optionname);
+                $this->assertEquals($value, $actualquestiondata->options->$optionname,
+                        'For property ' . $optionname);
             }
         }
 

--- a/tests/helper.php
+++ b/tests/helper.php
@@ -106,6 +106,7 @@ class qtype_coderunner_test_helper extends question_test_helper {
         $qdata->options->hidecheck = 0;
         $qdata->options->answerboxlines = 5;
         $qdata->options->displayfeedback = 1;
+        $qdata->options->giveupallowed = 0;
         // Exclude precheck as it defaults to null.
         $qdata->options->useace = 0;
         $qdata->options->penaltyregime = '10, 20, ...';
@@ -153,6 +154,7 @@ class qtype_coderunner_test_helper extends question_test_helper {
         $form->language = 'python3';
         $form->acelang = '';
         $form->displayfeedback = 1;
+        $form->giveupallowed = 0;
         $form->iscombinatortemplate = 0;
         $form->testsplitterre = '|#<ab@17943918#@>#\n|ms';
         $form->template = "{{ STUDENT_ANSWER }}\n{{ TEST.testcode }}\n";
@@ -216,6 +218,7 @@ class qtype_coderunner_test_helper extends question_test_helper {
         $form->language = 'python3';
         $form->acelang = '';
         $form->displayfeedback = 1;
+        $form->giveupallowed = 0;
         $form->iscombinatortemplate = 0;
         $form->testsplitterre = '|#<ab@17943918#@>#\n|ms';
         $form->template = "print('{{ STUDENT_ANSWER | e('py')}}\n";
@@ -1199,6 +1202,7 @@ EOPROG;
         $coderunner->hidecheck = 0;
         $coderunner->questiontext = $questiontext;
         $coderunner->displayfeedback = 1;
+        $coderunner->giveupallowed = 0;
         $coderunner->answer = '';
         $coderunner->answerpreload = '';
         $coderunner->globalextra = '';

--- a/tests/prototype_test.php
+++ b/tests/prototype_test.php
@@ -155,6 +155,7 @@ EOTEMPLATE;
     <filenamesregex></filenamesregex>
     <filenamesexplain></filenamesexplain>
     <displayfeedback>1</displayfeedback>
+    <giveupallowed>0</giveupallowed>
     <testcases>
       <testcase testtype="0" useasexample="0" hiderestiffail="0" mark="1.0000000" >
       <testcode>

--- a/version.php
+++ b/version.php
@@ -22,7 +22,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2021092600;
+$plugin->version  = 2021111000;
 $plugin->requires = 2019111800;
 $plugin->cron = 0;
 $plugin->component = 'qtype_coderunner';
@@ -30,6 +30,6 @@ $plugin->maturity = MATURITY_STABLE;
 $plugin->release = '4.1.0+';
 
 $plugin->dependencies = array(
-    'qbehaviour_adaptive_adapted_for_coderunner' => 2021022500
+    'qbehaviour_adaptive_adapted_for_coderunner' => 2021111000
 );
 


### PR DESCRIPTION
Clicking the button stops interaction with the question, and shows
the general feedback, taking the question to the state you would
reach after a quiz attempt has had the 'Submit all and finish' button
clicked.

See https://coderunner.org.nz/mod/forum/discuss.php?d=465. Note, this needs changes in both the qtype and the qbehaviour.