### PR TITLE
Stop button bug fixes

### DIFF
--- a/question.php
+++ b/question.php
@@ -495,7 +495,7 @@ class qtype_coderunner_question extends question_graded_automatically {
     /** Return a setting that determines whether or not the specific
      *  feedback display is controlled by the quiz settings or this particular
      *  question.
-     * @return bool FEEDBACK_USE_QUIZ, FEEDBACK_SHOW or FEEDBACK_HIDE from constants class.
+     * @return int FEEDBACK_USE_QUIZ, FEEDBACK_SHOW or FEEDBACK_HIDE from constants class.
      */
     public function display_feedback() {
         return isset($this->displayfeedback) ? intval($this->displayfeedback) : constants::FEEDBACK_USE_QUIZ;

--- a/renderer.php
+++ b/renderer.php
@@ -185,18 +185,25 @@ class qtype_coderunner_renderer extends qtype_renderer {
         /** @var qtype_coderunner_question $q */
         $q = $qa->get_question();
         $feedbackdisplay = $q->display_feedback();
+
+        // Update options for displaying specific feedback.
         if ($feedbackdisplay !== constants::FEEDBACK_USE_QUIZ && !empty($qa->get_last_qt_var('_testoutcome'))) {
             if ($feedbackdisplay === CONSTANTS::FEEDBACK_SHOW) {
                 $optionsclone->feedback = 1;
-                if ($qa->get_state()->is_finished() && $q->giveupallowed) {
-                    $optionsclone->generalfeedback = 1;
-                }
             } else if ($feedbackdisplay === CONSTANTS::FEEDBACK_HIDE) {
                 $optionsclone->feedback = 0;
             } else {
                 throw new coding_exception("Invalid value of feedbackdisplay: $feedbackdisplay");
             }
         }
+
+        // Update options for displaying general feedback.
+        if ($feedbackdisplay === CONSTANTS::FEEDBACK_SHOW) {
+            if ($qa->get_state()->is_finished() && $q->giveupallowed) {
+                $optionsclone->generalfeedback = 1;
+            }
+        }
+
         return parent::feedback($qa, $optionsclone);
     }
 

--- a/tests/walkthrough_test.php
+++ b/tests/walkthrough_test.php
@@ -399,6 +399,35 @@ EOTEMPLATE;
         //        $qa->summarise_action($qa->get_last_step()));
     }
 
+    public function test_stop_button_always_never_answered() {
+        $q = test_question_maker::make_question('coderunner', 'sqr');
+        $q->giveupallowed = constants::GIVEUP_ALWAYS;
+        $this->start_attempt_at_question($q, 'adaptive', 1, 1);
+        $qa = $this->get_question_attempt();
+
+        // Check the initial state.
+        $this->check_current_state(question_state::$todo);
+
+        // Click the Stop button.
+        $this->process_submission(array('-finish' => 1, 'answer' => ''));
+        $this->check_current_state(question_state::$gaveup);
+        $this->check_current_mark(0);
+        $this->check_current_output(
+                $this->get_does_not_contain_validation_error_expectation(),
+                $this->get_does_not_contain_stop_button_expectation(),
+                $this->get_no_hint_visible_expectation(),
+                $this->get_contains_general_feedback_expectation($q));
+        $this->assertEquals('Attempt finished submitting: ', $qa->summarise_action($qa->get_last_step()));
+
+        // Also check what happens in Quiz deferred feedback mode, when all the quiz display
+        // options are false, but the question is set to override that.
+        $q->displayfeedback = constants::FEEDBACK_SHOW;
+        $this->displayoptions->feedback = false;
+        $this->displayoptions->generalfeedback = false;
+        $this->check_current_output(
+                $this->get_contains_general_feedback_expectation($q));
+    }
+
     public function test_stop_button_after_max() {
         $q = test_question_maker::make_question('coderunner', 'sqr');
         $q->giveupallowed = constants::GIVEUP_AFTER_MAX_MARKS;


### PR DESCRIPTION
This goes with the pull request I just made for the behaviour.

Sorry we did not catch these before sending you the original pull request. Better late than never I hope. Luckily I work with an excellent tester.

Two problems: In deferred feedback quizzes, I was not interacting correctly with the forced feedback display option. And, there was a bug in the 'Available once improvement not possible' option, so the button never appeared if you kept getting the question wrong. (I expect you would approve :-).)