### PR TITLE
Add a capability to control who see hidden testcases.

### DIFF
--- a/classes/combinator_grader_outcome.php
+++ b/classes/combinator_grader_outcome.php
@@ -143,7 +143,7 @@ class qtype_coderunner_combinator_grader_outcome extends qtype_coderunner_testin
      * @return A table of test results. See the parent class for details.
      */
     public function get_test_results(qtype_coderunner_question $q) {
-        if (empty($this->testresults) || $this->can_view_hidden()) {
+        if (empty($this->testresults) || self::can_view_hidden()) {
             return $this->format_table($this->testresults);
         } else {
             return $this->format_table($this->visible_rows($this->testresults));

--- a/classes/testing_outcome.php
+++ b/classes/testing_outcome.php
@@ -243,7 +243,7 @@ class qtype_coderunner_testing_outcome {
      */
     protected function build_results_table(qtype_coderunner_question $question) {
         $resultcolumns = $question->result_columns();
-        $canviewhidden = $this->can_view_hidden();
+        $canviewhidden = self::can_view_hidden();
 
         // Build the table header, containing all the specified field headers,
         // unless all rows in that column would be blank.
@@ -395,7 +395,7 @@ class qtype_coderunner_testing_outcome {
         global $COURSE;
 
         if ($COURSE && $coursecontext = context_course::instance($COURSE->id)) {
-            $canviewhidden = has_capability('moodle/grade:viewhidden', $coursecontext);
+            $canviewhidden = has_capability('qtype/coderunner:viewhiddentestcases', $coursecontext);
         } else {
             $canviewhidden = false;
         }

--- a/db/access.php
+++ b/db/access.php
@@ -15,20 +15,38 @@
 // along with CodeRunner.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Define a new capability that gives access to the sandbox web service.
- * Default allows any authenticated user to access.
+ * Capability definitions for the qtype_coderunner plugin.
+ *
+ * @package   qtype_coderunner
+ * @category  access
+ * @copyright 2022 Richard Lobb, University of Canterbury
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-$capabilities = array(
-    'qtype/coderunner:sandboxwsaccess' => array(
+$capabilities = [
+    // When reviewing questions, whether the hidden testcases are shown. Intended for teacher-like roles.
+    'qtype/coderunner:viewhiddentestcases' => [
+        'riskbitmask' => 0,
+        'captype' => 'read',
+        'contextlevel' => CONTEXT_COURSE,
+        'archetypes' => [
+            'teacher' => CAP_ALLOW,
+            'editingteacher' => CAP_ALLOW,
+            'manager' => CAP_ALLOW
+        ],
+        'clonepermissionsfrom' => 'moodle/grade:viewhidden'
+    ],
+
+    // Who can use the sandbox web service (and therefore use the ace_inline filter).
+    'qtype/coderunner:sandboxwsaccess' => [
         'riskbitmask'  => 0, // No standard risks apply. Only potential DoS.
         'captype'      => 'write',
         'contextlevel' => CONTEXT_SYSTEM,
-        'archetypes'   => array(
+        'archetypes'   => [
             'student'        => CAP_ALLOW,
             'teacher'        => CAP_ALLOW,
             'editingteacher' => CAP_ALLOW,
             'manager'        => CAP_ALLOW
-        )
-    )
-);
+        ]
+    ]
+];

--- a/lang/en/qtype_coderunner.php
+++ b/lang/en/qtype_coderunner.php
@@ -103,6 +103,7 @@ $string['coderunner_install_testsuite_failures'] = 'Tests that failed';
 $string['coderunner_install_testsuite_noanswer'] = 'Questions without sample answers';
 
 $string['coderunner:sandboxwsaccess'] = 'Allow access to the Jobe sandbox via web services';
+$string['coderunner:viewhiddentestcases'] = 'See hidden testcases when reviewing questions';
 $string['coderunner_help'] = 'In response to a question, which is a specification for a program fragment, function or whole program, the respondent enters source code in a specified computer language that satisfies the specification.';
 $string['coderunner_link'] = 'question/type/coderunner';
 $string['coderunner_question_type'] = 'CodeRunner question type: ';

--- a/version.php
+++ b/version.php
@@ -22,7 +22,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2022012703;
+$plugin->version  = 2022022300;
 $plugin->requires = 2019111800;
 $plugin->cron = 0;
 $plugin->component = 'qtype_coderunner';


### PR DESCRIPTION
Previously CodeRunner re-used the core capability moodle/grade:viewhidden
but having our own capability gives more control. On upgrade,
the existing permissions should be copied.

As previously discussed in the forum: https://coderunner.org.nz/mod/forum/discuss.php?d=486