### PR TITLE
Unit test fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - php: '8.0'
+            moodle-branch: 'master'
+            database: 'pgsql'
           - php: '7.4'
-            moodle-branch: 'MOODLE_400_STABLE'
+            moodle-branch: 'MOODLE_401_STABLE'
             database: 'pgsql'
           - php: '7.3'
             moodle-branch: 'MOODLE_400_STABLE'
@@ -18,7 +21,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:10
+        image: postgres:13
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -119,7 +122,7 @@ jobs:
         run: moodle-plugin-ci mustache
 
       - name: Grunt
-        if: ${{ always() }}
+        if: ${{ matrix.moodle-branch == 'MOODLE_400_STABLE' }}
         run: moodle-plugin-ci grunt
 
       - name: PHPUnit tests

--- a/tests/phpquestions_test.php
+++ b/tests/phpquestions_test.php
@@ -39,6 +39,7 @@ require_once($CFG->dirroot . '/question/type/coderunner/tests/test.php');
 class phpquestions_test extends \qtype_coderunner_testcase {
 
     public function test_good_sqr_function() {
+        $this->check_language_available('php');
         $q = $this->make_question('sqrphp');
         $response = array('answer' => "<?php\nfunction sqr(\$n) { return \$n * \$n; }\n");
         list($mark, $grade, $cache) = $q->grade_response($response);
@@ -52,6 +53,7 @@ class phpquestions_test extends \qtype_coderunner_testcase {
 
 
     public function test_bad_sqr_function() {
+        $this->check_language_available('php');
         $q = $this->make_question('sqrphp');
         $response = array('answer' => "<?php\nfunction sqr(\$n) { return \$n; }\n");
         list($mark, $grade, $cache) = $q->grade_response($response);
@@ -65,6 +67,7 @@ class phpquestions_test extends \qtype_coderunner_testcase {
 
 
     public function test_bad_syntax() {
+        $this->check_language_available('php');
         $q = $this->make_question('sqrphp');
         $response = array('answer' => "<?php\nfunction sqr(\$n) { return \$n\n");
         list($mark, $grade, $cache) = $q->grade_response($response);

--- a/tests/walkthrough_test.php
+++ b/tests/walkthrough_test.php
@@ -24,8 +24,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-use qtype_coderunner\constants;
-
 namespace qtype_coderunner;
 
 defined('MOODLE_INTERNAL') || die();


### PR DESCRIPTION
When I upgarded our to CodeRunner 5.1.1 running on PHP 8.0 we got some issues with the unit tests:

1. There was an error because of an (unecessary) use statement above the namespace statement in one file.
2. Someone, or Jobe standbox thinks that PHP is not an aviable language (even though Jobe is implemented in PHP!) So I added a check for the language being available to those unit tests.
3. And I updated the github action config to: a) Test with PHP8 as well as other versions. b) Run the tests with Moodle 4.1 and master, as well as 4.0. I can see you have been working on fixing some of the fails on the devel branch, so I did not do more.

Let me know if you would like me to change any of this.