### PR TITLE
Fix PHP8.1 deprecated error for trim function

### DIFF
--- a/questiontype.php
+++ b/questiontype.php
@@ -358,7 +358,7 @@ class qtype_coderunner extends question_type {
             }
         }
 
-        if (trim($question->sandbox) === 'DEFAULT') {
+        if (trim($question->sandbox ?? '') === 'DEFAULT') {
             $question->sandbox = null;
         }
 


### PR DESCRIPTION
Hi Richard,

Good afternoon!

To introduce myself, I am Anupama Sarjoshi, working in The Open University in the same team as @timhunt. 

We saw the following error in trim function when we updated to PHP8.1

Error:
Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/moodle/question/type/coderunner/questiontype.php on line 361

I have done the fix for the same. Could you please review?

Thanks,
Anupama