### PR TITLE
Fix some more PHP8.1 deprecation errors

### DIFF
--- a/classes/jobesandbox.php
+++ b/classes/jobesandbox.php
@@ -135,7 +135,7 @@ class qtype_coderunner_jobesandbox extends qtype_coderunner_sandbox {
 
     public function execute($sourcecode, $language, $input, $files=null, $params=null) {
         $language = strtolower($language);
-        if ($input !== '' && substr($input, -1) != "\n") {
+        if (trim($input ?? '') !== '' && substr($input, -1) != "\n") {
             $input .= "\n";  // Force newline on the end if necessary.
         }
 

--- a/classes/ui_parameters.php
+++ b/classes/ui_parameters.php
@@ -111,7 +111,9 @@ class qtype_coderunner_ui_parameters {
      * already have a key, ignore it. Otherwise an exception is raised.
      */
     public function merge_json($json, $ignorebad=false) {
-        $newvalues = json_decode($json);
+        if(isset($json)) {
+            $newvalues = json_decode($json);
+        }
         if ($newvalues !== null) {  // If $json is valid.
             foreach ($newvalues as $key => $value) {
                 $matchingkey = $this->find_key($key);

--- a/renderer.php
+++ b/renderer.php
@@ -508,7 +508,7 @@ class qtype_coderunner_renderer extends qtype_renderer {
         }
         $fieldname = $qa->get_qt_field_name('sampleanswer');
         $currentlanguage = $question->acelang ? $question->acelang : $question->language;
-        if (strpos($question->acelang, ',') !== false) {
+        if (isset($question->acelang) && strpos($question->acelang, ',') !== false) {
             // Case of a multilanguage question sample answer. Find the language,
             // which is specified by the template parameter answer_language if
             // given, or the default (starred) language in the language list

--- a/vendor/twig/twig/src/Node/Node.php
+++ b/vendor/twig/twig/src/Node/Node.php
@@ -145,7 +145,7 @@ class Node implements \Countable, \IteratorAggregate
         unset($this->nodes[$name]);
     }
 
-    public function count()
+    public function count(): int
     {
         return \count($this->nodes);
     }


### PR DESCRIPTION
Hi Richard,

We have noticed some more PHP deprecation errors related to PHP8.1. Could you please review the patch?

Errors:

1. Deprecated: json_decode(): Passing null to parameter #1 ($json) of type string is deprecated in /var/www/html/moodle/question/type/coderunner/classes/ui_parameters.php on line 114

2. Deprecated: Return type of Twig\Node\Node::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/html/moodle/question/type/coderunner/vendor/twig/twig/src/Node/Node.php on line 148

3. Deprecated: substr(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/moodle/question/type/coderunner/classes/jobesandbox.php on line 138

4. Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in C:\Users\as38293\workspace\ou-moodle2\question\type\coderunner\renderer.php on line 511

Thanks,
Anupama