### PR TITLE
Php8.1compatibilty

### DIFF
--- a/backup/moodle2/restore_qtype_coderunner_plugin.class.php
+++ b/backup/moodle2/restore_qtype_coderunner_plugin.class.php
@@ -119,14 +119,14 @@ class restore_qtype_coderunner_plugin extends restore_qtype_plugin {
 
             // Convert pre-version 3.1 fields to post 3.1.
             if (isset($data->pertesttemplate) &&
-                    trim($data->pertesttemplate) != '' &&
+                    trim($data->pertesttemplate ?? '') != '' &&
                     empty($data->enablecombinator) &&
                     $data->grader != 'CombinatorTemplateGrader') {
                 $data->template = $data->pertesttemplate;
                 $data->iscombinatortemplate = 0;
             }
             if (isset($data->combinatortemplate) &&
-                    trim($data->combinatortemplate) != '' &&
+                    trim($data->combinatortemplate ?? '') != '' &&
                     ((isset($data->enablecombinator) && $data->enablecombinator == 1 )
                             || $data->grader == 'CombinatorTemplateGrader')) {
                 $data->template = $data->combinatortemplate;

--- a/classes/bulk_tester.php
+++ b/classes/bulk_tester.php
@@ -256,7 +256,7 @@ class qtype_coderunner_bulk_tester {
     private function load_and_test_question($questionid) {
         try {
             $question = question_bank::load_question($questionid);
-            if (empty(trim($question->answer))) {
+            if (empty(trim($question->answer ?? ''))) {
                 $message = get_string('nosampleanswer', 'qtype_coderunner');
                 $status = self::MISSINGANSWER;
             } else {

--- a/classes/external/run_in_sandbox.php
+++ b/classes/external/run_in_sandbox.php
@@ -147,7 +147,7 @@ class run_in_sandbox extends external_api {
             } else {
                 $paramsarray['cputime'] = $maxcputime;
             }
-            $jobehostws = trim(get_config('qtype_coderunner', 'wsjobeserver'));
+            $jobehostws = trim(get_config('qtype_coderunner', 'wsjobeserver') ?? '');
             if ($jobehostws !== '') {
                 $paramsarray['jobeserver'] = $jobehostws;
             }

--- a/classes/ideonesandbox.php
+++ b/classes/ideonesandbox.php
@@ -75,7 +75,7 @@ class qtype_coderunner_ideonesandbox extends qtype_coderunner_sandbox {
         if ($this->langserror == self::OK) {
             foreach ($response['languages'] as $id => $lang) {
                 $endofname = strpos($lang, ' (');
-                $shortlangname = strtolower(trim(substr($lang, 0, $endofname)));
+                $shortlangname = strtolower(trim(substr($lang ?? '', 0, $endofname)));
                 if (empty($this->langmap[$shortlangname])) {
                     $this->langmap[$shortlangname] = $id;
                 }

--- a/classes/jobesandbox.php
+++ b/classes/jobesandbox.php
@@ -226,7 +226,7 @@ class qtype_coderunner_jobesandbox extends qtype_coderunner_sandbox {
         } else {
             $stderr = $this->filter_file_path($this->response->stderr);
             // Any stderr output is treated as a runtime error.
-            if (trim($stderr) !== '') {
+            if (trim($stderr ?? '') !== '') {
                 $this->response->outcome = self::RESULT_RUNTIME_ERROR;
             }
             $this->currentjobid = null;

--- a/classes/jobrunner.php
+++ b/classes/jobrunner.php
@@ -322,7 +322,7 @@ class qtype_coderunner_jobrunner {
     private function merge($sep, $strings) {
         $s = '';
         foreach ($strings as $el) {
-            if (trim($el)) {
+            if (trim($el ?? '')) {
                 if ($s !== '') {
                     $s .= $sep;
                 }

--- a/classes/regex_grader.php
+++ b/classes/regex_grader.php
@@ -50,7 +50,7 @@ class qtype_coderunner_regex_grader extends qtype_coderunner_grader {
      *  etc).
      */
     public function grade_known_good(&$output, &$testcase) {
-        $regex = '/' . str_replace('/', '\/', rtrim($testcase->expected)) . '/ms';
+        $regex = '/' . str_replace('/', '\/', rtrim($testcase->expected ?? '')) . '/ms';
         $iscorrect = preg_match($regex, $output);
         $awardedmark = $iscorrect ? $testcase->mark : 0.0;
         return new qtype_coderunner_test_result($testcase, $iscorrect, $awardedmark, $output);

--- a/classes/util.php
+++ b/classes/util.php
@@ -218,7 +218,7 @@ class qtype_coderunner_util {
         $filteredlangs = array();
         $defaultlang = '';
         foreach ($langs as $lang) {
-            $lang = trim($lang);
+            $lang = trim($lang ?? '');
             if ($lang === '') {
                 continue;
             }

--- a/edit_coderunner_form.php
+++ b/edit_coderunner_form.php
@@ -869,7 +869,7 @@ class qtype_coderunner_edit_form extends question_edit_form {
         if ($data['prototypetype'] == 2 && ($data['saved_prototype_type'] != 2 ||
                    $data['typename'] != $data['coderunnertype'])) {
             // User-defined prototype, either newly created or undergoing a name change.
-            $typename = trim($data['typename']);
+            $typename = trim($data['typename'] ?? '');
             if ($typename === '') {
                 $errors['prototypecontrols'] = get_string('empty_new_prototype_name', 'qtype_coderunner');
             } else if (!$this->is_valid_new_type($typename)) {
@@ -882,7 +882,7 @@ class qtype_coderunner_edit_form extends question_edit_form {
              $errors['markinggroup'] = $penaltyregimeerror;
         }
 
-        $resultcolumnsjson = trim($data['resultcolumns']);
+        $resultcolumnsjson = trim($data['resultcolumns'] ?? '');
         if ($resultcolumnsjson !== '') {
             $resultcolumns = json_decode($resultcolumnsjson);
             if ($resultcolumns === null) {
@@ -924,7 +924,7 @@ class qtype_coderunner_edit_form extends question_edit_form {
             }
         }
 
-        $acelangs = trim($data['acelang']);
+        $acelangs = trim($data['acelang'] ?? '');
         if ($acelangs !== '' && strpos($acelangs, ',') !== false) {
             $parsedlangs = qtype_coderunner_util::extract_languages($acelangs);
             if ($parsedlangs === false) {
@@ -1052,7 +1052,7 @@ class qtype_coderunner_edit_form extends question_edit_form {
         // Check the penalty regime and return an error string or an empty string if OK.
         $errorstring = '';
         $expectedpr = '/[0-9]+(\.[0-9]*)?%?([, ] *[0-9]+(\.[0-9]*)?%?)*([, ] *...)?/';
-        $penaltyregime = trim($data['penaltyregime']);
+        $penaltyregime = trim($data['penaltyregime'] ?? '');
         if ($penaltyregime == '') {
             $errorstring = get_string('emptypenaltyregime', 'qtype_coderunner');
         } else if (!preg_match($expectedpr, $penaltyregime)) {
@@ -1143,15 +1143,15 @@ class qtype_coderunner_edit_form extends question_edit_form {
         $numnonemptytests = 0;
         $num = max(count($testcodes), count($stdins), count($expecteds));
         for ($i = 0; $i < $num; $i++) {
-            $testcode = trim($testcodes[$i]);
+            $testcode = trim($testcodes[$i] ?? '');
             if ($testcode != '') {
                 $numnonemptytests++;
             }
-            $stdin = trim($stdins[$i]);
-            $expected = trim($expecteds[$i]);
+            $stdin = trim($stdins[$i] ?? '');
+            $expected = trim($expecteds[$i] ?? '');
             if ($testcode !== '' || $stdin != '' || $expected !== '') {
                 $count++;
-                $mark = trim($marks[$i]);
+                $mark = trim($marks[$i] ?? '');
                 if ($mark != '') {
                     if (!is_numeric($mark)) {
                         $errors["testcode[$i]"] = get_string('nonnumericmark', 'qtype_coderunner');
@@ -1179,14 +1179,14 @@ class qtype_coderunner_edit_form extends question_edit_form {
         $attachmentssaver = $this->get_sample_answer_file_saver();
         $files = $attachmentssaver ? $attachmentssaver->get_files() : array();
         $answer = $this->formquestion->answer;
-        if (trim($answer) === '' && count($files) == 0) {
+        if (trim($answer ?? '') === '' && count($files) == 0) {
             return ''; // Empty answer and no attachments.
         }
         // Check if it's a multilanguage question; if so need to determine
         // what language to use. If there is a specific answer_language template
         // parameter, that is used. Otherwise the default language (if specified)
         // or the first in the list is used.
-        $acelang = trim($this->formquestion->acelang);
+        $acelang = trim($this->formquestion->acelang ?? '');
         if ($acelang !== '' && strpos($acelang, ',') !== false) {
             if (empty($this->formquestion->parameters['answer_language'])) {
                 list($languages, $answerlang) = qtype_coderunner_util::extract_languages($acelang);

--- a/question.php
+++ b/question.php
@@ -693,7 +693,7 @@ class qtype_coderunner_question extends question_graded_automatically {
      * @param string $text Text to be twig expanded.
      */
     public function twig_expand($text, $context=array()) {
-        if (empty(trim($text))) {
+        if (empty(trim($text ?? ''))) {
             return $text;
         } else {
             $context['QUESTION'] = $this->sanitised_clone_of_this();

--- a/questiontype.php
+++ b/questiontype.php
@@ -211,8 +211,8 @@ class qtype_coderunner extends question_type {
             $stdin = $this->filter_crs($question->stdin[$i]);
             $expected = $this->filter_crs($question->expected[$i]);
             $extra = $this->filter_crs($question->extra[$i]);
-            if (trim($testcode) === '' && trim($stdin) === '' &&
-                    trim($expected) === '' && trim($extra) === '') {
+            if (trim($testcode ?? '') === '' && trim($stdin ?? '') === '' &&
+                    trim($expected ?? '') === '' && trim($extra ?? '') === '') {
                 continue; // Ignore testcases with only whitespace in them.
             }
             $testcase = new stdClass;
@@ -352,7 +352,7 @@ class qtype_coderunner extends question_type {
         foreach ($fields as $field) {
             $isinherited = !in_array($field, $this->noninherited_fields());
             $isblankstring = !isset($question->$field) ||
-               (is_string($question->$field) && trim($question->$field) === '');
+               (is_string($question->$field) && trim($question->$field ?? '') === '');
             if ($isinherited && ($isblankstring || $questioninherits)) {
                 $question->$field = null;
             }
@@ -463,7 +463,7 @@ class qtype_coderunner extends question_type {
             $target->grader = null;
         }
 
-        if (!isset($target->sandboxparams) || trim($target->sandboxparams) === '') {
+        if (!isset($target->sandboxparams) || trim($target->sandboxparams ?? '') === '') {
             $target->sandboxparams = null;
         }
     }

--- a/renderer.php
+++ b/renderer.php
@@ -671,13 +671,13 @@ class qtype_coderunner_renderer extends qtype_renderer {
         $numtests = 0;
         $numextras = 0;
         foreach ($tests as $test) {
-            if (trim($test->stdin) !== '') {
+            if (trim($test->stdin ?? '') !== '') {
                 $numstds++;
             }
-            if (trim($test->testcode) !== '') {
+            if (trim($test->testcode ?? '') !== '') {
                 $numtests++;
             }
-            if (trim($test->extra) !== '') {
+            if (trim($test->extra ?? '') !== '') {
                 $numextras++;
             }
         }
@@ -717,7 +717,7 @@ class qtype_coderunner_renderer extends qtype_renderer {
     private function column_format($field, $resultcolumns) {
         foreach ($resultcolumns as $columnspecifier) {
             if (count($columnspecifier) > 2 && $columnspecifier[1] === $field) {
-                return trim($columnspecifier[2]);
+                return trim($columnspecifier[2] ?? '');
             }
         }
         return '%s';


### PR DESCRIPTION
Hi Richard, thanks for pushing the first commit (#174 on master branch), I have added the second commit (532d3de488278670baa8d250d1abfe577c063b97) which was a fix for the following:

```
Error-Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/moodle/question/type/coderunner/edit_coderunner_form.php on line 1189

Link-[Editing a CodeRunner question (open.ac.uk)](https://learn2acct.open.ac.uk/question/bank/editquestion/question.php)

Steps to reproduce: 

1. Enter the Learn2acct URL and login as a staff
2. search a course and add the quiz
3. Navigate to WebAministration> Question Bank> question>
4. Click on ' create new question 'Button .
5. Choose 'coderunner ' Qtype.
6.  Question form should open .
7. Proved 'Answer' and tick the check box of 'Validate on Save'
8. Provide all necessary data and ' Save'
9. Observed Deprecated error on top of the page as below screenshots​

Expected: we shouldn't get any error 
ACTUAL: Observed Deprecated error When Creating Question.
```

I have also modified other areas of the code, where trim function was used and I thought could be relevant. 
