### PR TITLE
Add validation: Sandbox lang cannot be empty when creating a prototype

### DIFF
--- a/edit_coderunner_form.php
+++ b/edit_coderunner_form.php
@@ -904,6 +904,11 @@ class qtype_coderunner_edit_form extends question_edit_form {
             $errors = array_merge($errors, $testcaseerrors);
         }
 
+        if ($data['prototypetype'] == 2 && empty($data['language'])) {
+            // Language cannot be empty when it is a prototype template.
+            $errors['languages'] = get_string('emptysandboxlanguage', 'qtype_coderunner');
+        }
+
         if ($data['iscombinatortemplate'] && empty($data['testsplitterre'])) {
             $errors['templatecontrols'] = get_string('bad_empty_splitter', 'qtype_coderunner');
         }

--- a/lang/en/qtype_coderunner.php
+++ b/lang/en/qtype_coderunner.php
@@ -146,6 +146,7 @@ $string['duplicateprototype'] = 'This question was defined to be of type \'{$a->
 $string['editingcoderunner'] = 'Editing a CodeRunner Question';
 $string['empty_new_prototype_name'] = 'New question type name cannot be empty';
 $string['emptypenaltyregime'] = 'Penalty regime must be defined (since version 3.1)';
+$string['emptysandboxlanguage'] = 'Sandbox language cannot be empty when creating a prototype.';
 $string['enable'] = 'Enable';
 $string['enablecombinator'] = 'Enable combinator';
 $string['enable_diff_check'] = 'Enable \'Show differences\' button';

--- a/tests/behat/make_prototype.feature
+++ b/tests/behat/make_prototype.feature
@@ -77,3 +77,13 @@ Feature: make_prototype
     And I set the field "prototypetype" to "No"
     And I set the field "id_coderunnertype" to "python3" and dismiss the alert
     Then I should not see "This is a prototype; cannot change question type"
+
+  Scenario: As a teacher, when I try to create the prototype with empty Sandbox language I should see the validation error
+    Given I am on the "PROTOTYPE_test_prototype" "core_question > edit" page logged in as teacher1
+    And I click on "a[aria-controls='id_advancedcustomisationheadercontainer']" "css_element"
+    When I set the field "language" to ""
+    And I press "id_submitbutton"
+    Then I should see "Sandbox language cannot be empty when creating a prototype."
+    And I set the field "language" to "python3"
+    And I press "id_submitbutton"
+    And I should see "Question bank"


### PR DESCRIPTION
Hi Richard,

We are seeing the following deprecation warnings on some of our questions. Warning is in the function `answerbox_attributes`, when `$currentlanguage` is null and` ucwords` doesn't accept it. 

`Deprecated: ucwords(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/moodle/question/type/coderunner/renderer.php on line 749`

Have noticed that the questions with these warnings are all using user defined prototype templates (which seems to have been deleted on our systems). But the problem here is when I looked into the database table question_coderunner_options, the language for these user defined prototypes is set to null. 

And I suppose, we should never have a user defined prototype template with empty sandbox language. Hence adding a validation to the sandbox language would prevent those issues. Though adding `ucwords($currentlanguage ?? '');` would fix the existing issues as well, I was not sure if that is the right thing to do and thought would be good to confirm before doing that change.  

Could you please have a look and suggest if I have understood it correctly and the fix is right?

I was able to reproduce this issue with the following steps:
1. Create an user defined prototype template.
2. Edit the prototype template. Navigate to 'Advanced customisation'. 
3. Set 'Sandbox language' to ''
4. Save the prototype and preview. 
6. Notice that the above warning message is displayed.

Thanks,
Anupama