### PR TITLE
fix: gigantic vh in chrome & safari on some themes

### DIFF
--- a/templates/scratchpad_ui.mustache
+++ b/templates/scratchpad_ui.mustache
@@ -42,7 +42,7 @@
         }
     }
 }}
-<div style='min-height:100%' class='qtype-coderunner-sp-outer-div'>
+<div class='qtype-coderunner-sp-outer-div'>
     {{# answer_code }}{{> qtype_coderunner/answer_textarea }}{{/ answer_code }}
     {{^ disable_scratchpad }}{{> qtype_coderunner/scratchpad }}{{/ disable_scratchpad }}
 </div>


### PR DESCRIPTION
Fix for issue:
https://github.com/trampgeek/moodle-qtype_coderunner/issues/198

Changes:
Remove unnecessary `min-height` style from div.