### PR TITLE
Fix warning - undefined property behat_prefix

### DIFF
--- a/classes/jobesandbox.php
+++ b/classes/jobesandbox.php
@@ -71,7 +71,8 @@ class qtype_coderunner_jobesandbox extends qtype_coderunner_sandbox {
         global $CFG;
         qtype_coderunner_sandbox::__construct();
         $this->jobeserver = get_config('qtype_coderunner', 'jobe_host');
-        if ($this->jobeserver === 'jobe2.cosc.canterbury.ac.nz' && $CFG->prefix === $CFG->behat_prefix) {
+        if (qtype_coderunner_sandbox::is_canterbury_server($this->jobeserver)
+                && qtype_coderunner_sandbox::is_using_test_sandbox()) {
             throw new Exception("Please don't use the Canterbury jobe server for test runs");
         }
         $this->apikey = get_config('qtype_coderunner', 'jobe_apikey');

--- a/classes/sandbox.php
+++ b/classes/sandbox.php
@@ -34,9 +34,11 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+use qtype_coderunner\constants;
+
 global $CFG;
 
-if ($CFG->prefix == $CFG->behat_prefix) {
+if (qtype_coderunner_sandbox::is_using_test_sandbox()) {
     require_once($CFG->dirroot .'/question/type/coderunner/tests/fixtures/test-sandbox-config.php');
 }
 
@@ -207,6 +209,24 @@ abstract class qtype_coderunner_sandbox {
             }
         }
         return $enabled;
+    }
+
+    /**
+     * Returns true if sandbox is being used for tests.
+     * @return bool
+     */
+    public static function is_using_test_sandbox(): bool {
+        global $CFG;
+        return !empty($CFG->behat_prefix) && $CFG->prefix === $CFG->behat_prefix;
+    }
+
+    /**
+     * Returns true if canterbury jobe server is being used.
+     * @param string jobeserver being used.
+     * @return bool
+     */
+    public static function is_canterbury_server(string $jobeserver): bool {
+        return $jobeserver === constants::JOBE_HOST_DEFAULT;
     }
 
     /**

--- a/edit_coderunner_form.php
+++ b/edit_coderunner_form.php
@@ -250,7 +250,7 @@ class qtype_coderunner_edit_form extends question_edit_form {
         $mform->addHelpButton('sampleanswerattachments', 'sampleanswerattachments', 'qtype_coderunner');
         // Unless behat is running, hide the attachments file picker.
         // behat barfs if it's hidden.
-        if ($CFG->prefix !== $CFG->behat_prefix) {
+        if (!qtype_coderunner_sandbox::is_using_test_sandbox()) {
             $method = method_exists($mform, 'hideIf') ? 'hideIf' : 'disabledIf';
             $mform->$method('sampleanswerattachments', 'attachments', 'eq', 0);
         }

--- a/renderer.php
+++ b/renderer.php
@@ -411,7 +411,8 @@ class qtype_coderunner_renderer extends qtype_renderer {
         if (isset($sandboxinfo['jobeserver'])) {
             $jobeserver = $sandboxinfo['jobeserver'];
             $apikey = $sandboxinfo['jobeapikey'];
-            if ($jobeserver == constants::JOBE_HOST_DEFAULT && $CFG->prefix !== $CFG->behat_prefix) {
+            if (qtype_coderunner_sandbox::is_canterbury_server($jobeserver)
+                    && (!qtype_coderunner_sandbox::is_using_test_sandbox())) {
                 if ($apikey == constants::JOBE_HOST_DEFAULT_API_KEY) {
                     $fb .= get_string('jobe_warning_html', 'qtype_coderunner');
                 } else {


### PR DESCRIPTION
Hi Richard,

We see some of the warnings with PHP8.2 
Coderunner version 2024031500  
release '5.3.1'.

Noticed the below warnings when we edit the Coderuner questions:

Warning: Undefined property: stdClass::$behat_prefix in /var/www/html/moodle/question/type/coderunner/classes/sandbox.php on line 39
Warning: Undefined property: stdClass::$behat_prefix in /var/www/html/moodle/question/type/coderunner/edit_coderunner_form.php on line 253

Could you please review the fix and suggest if it looks good?

Thanks,
Anupama
