### PR TITLE
Add missing prototypeextra field to Twig QUESTION variable.

### DIFF
--- a/question.php
+++ b/question.php
@@ -981,7 +981,7 @@ class qtype_coderunner_question extends question_graded_automatically {
         $clone = new stdClass();
         $fieldsrequired = ['id', 'name', 'questiontext', 'generalfeedback',
             'generalfeedbackformat', 'testcases',
-            'answer', 'answerpreload', 'language', 'globalextra', 'useace', 'sandbox',
+            'answer', 'answerpreload', 'language', 'globalextra', 'prototypeextra', 'useace', 'sandbox',
             'grader', 'cputimelimitsecs', 'memlimitmb', 'sandboxparams',
             'parameters', 'resultcolumns', 'allornothing', 'precheck',
             'hidecheck', 'penaltyregime', 'iscombinatortemplate',


### PR DESCRIPTION
I added 'prototypeextra' to $fieldsrequired in the 'sanitised_clone_of_this' method. Without it, the expansion result of {{ QUESTION.prototypeextra }} will be empty.