### PR TITLE
Adding category and course shortname to bulk test report

### DIFF
--- a/classes/bulk_tester.php
+++ b/classes/bulk_tester.php
@@ -187,15 +187,17 @@ class qtype_coderunner_bulk_tester {
         global $OUTPUT;
 
         // Load the necessary data.
+        $coursename = $context->get_context_name(true, true);
         $categories = $this->get_categories_for_context($context->id);
         $questiontestsurl = new moodle_url('/question/type/coderunner/questiontestrun.php');
         if ($context->contextlevel == CONTEXT_COURSE) {
-            $questiontestsurl->param('courseid', $context->instanceid);
+            $qparams['courseid'] = $context->instanceid;
         } else if ($context->contextlevel == CONTEXT_MODULE) {
-            $questiontestsurl->param('cmid', $context->instanceid);
+            $qparams['cmid'] = $context->instanceid;
         } else {
-            $questiontestsurl->param('courseid', SITEID);
+            $qparams['courseid'] = SITEID;
         }
+        $questiontestsurl->params($qparams);
         $numpasses = 0;
         $failingtests = [];
         $missinganswers = [];
@@ -233,12 +235,17 @@ class qtype_coderunner_bulk_tester {
                 // Report the result, and record failures for the summary.
                 echo " $message</li>";
                 flush(); // Force output to prevent timeouts and show progress.
+                $qparams['category'] = $currentcategoryid . ',' . $context->id;
+                $qparams['lastchanged'] = $question->id;
+                $qparams['qperpage'] = 1000;
+                $questionbankurl = new moodle_url('/question/edit.php', $qparams);
+                $questionbanklink = html_writer::link($questionbankurl, $nameandcount->name, ['target' => '_blank']);
                 if ($outcome === self::PASS) {
                     $numpasses += 1;
                 } else if ($outcome === self::MISSINGANSWER) {
-                    $missinganswers[] = $questionnamelink;
+                    $missinganswers[] = "$coursename / $questionbanklink / $questionnamelink";
                 } else {
-                    $failingtests[] = "$questionnamelink: $message";
+                    $failingtests[] = "$coursename / $questionbanklink / $questionnamelink: $message";
                 }
             }
             echo "</ul>\n";


### PR DESCRIPTION
Hi Richard,

Here is a small change to the bulk test reports to display the course and the category names (with link to the question bank) for the test failures. This would be very useful to see if any question is in a "test" category, or on a workspace, and could be ignored. Also will be easy to identify the questions that are failing on live module presentations. Could you please review?

Currently, the report is shown as:


![image](https://github.com/trampgeek/moodle-qtype_coderunner/assets/81178902/3b0f0b68-3944-4989-bf61-cb7b706ef0c5)

New report will be:

![image](https://github.com/trampgeek/moodle-qtype_coderunner/assets/81178902/0c93904e-77ff-4324-bbb8-804319ede802)


Thanks,
Anupama