### PR TITLE
Fix side effects of question duplication bug patch

### DIFF
--- a/backup/moodle2/restore_qtype_coderunner_plugin.class.php
+++ b/backup/moodle2/restore_qtype_coderunner_plugin.class.php
@@ -150,16 +150,19 @@ class restore_qtype_coderunner_plugin extends restore_qtype_plugin {
         $questiondata = parent::convert_backup_to_questiondata($backupdata);
         $qtype = $questiondata->qtype;
 
-        $questiondata->options->testcases = [];
-        foreach ($backupdata["plugin_qtype_{$qtype}_question"]['coderunner_testcases']['coderunner_testcase'] as $record) {
-            $testcase = new stdClass();
-            $fields = [ 'testcode', 'testtype', 'expected', 'useasexample', 'display',
-                'hiderestiffail', 'mark', 'stdin', 'extra'];
-            foreach ($fields as $field) {
-                $testcase->$field = $record[$field];
+        if (isset($backupdata["plugin_qtype_{$qtype}_question"]['coderunner_testcases'])) {
+            $questiondata->options->testcases = [];
+            foreach ($backupdata["plugin_qtype_{$qtype}_question"]['coderunner_testcases']['coderunner_testcase'] as $record) {
+                $testcase = new stdClass();
+                $fields = [ 'testcode', 'testtype', 'expected', 'useasexample', 'display',
+                    'hiderestiffail', 'mark', 'stdin', 'extra'];
+                foreach ($fields as $field) {
+                    $testcase->$field = $record[$field];
+                }
+                $questiondata->options->testcases[] = $testcase;
             }
-            $questiondata->options->testcases[] = $testcase;
         }
+
         if (isset($backupdata["plugin_qtype_{$qtype}_question"]['coderunner_options'])) {
             $questiondata->options = (object) array_merge(
                 (array) $questiondata->options,


### PR DESCRIPTION
I did some testing and 59cda8c238b3aedfa4fd5d3224aba56eef2cbca0 seems to introduce side effects that make  `mod/quiz/tests/backup/repeated_restore_test.php` fail.

---

Before 59cda8c238b3aedfa4fd5d3224aba56eef2cbca0:
```
/usr/share/nginx/www/moodle $ php vendor/bin/phpunit --color mod/quiz/tests/backup/repeated_restore_test.php
Moodle 4.5.3 (Build: 20250317), d069cb93378d39ee00ce5f30cc520aaee4ae496c
Php: 8.3.19, pgsql: 14.17, OS: Linux 6.13.8-arch1-1 x86_64
PHPUnit 9.6.18 by Sebastian Bergmann and contributors.

.....SSSS.SS..SS...S.S..................S....................S.  63 / 115 ( 54%)
.....SSSS.SS..SS...S.S....S..S.SS.S.....S..S........            115 / 115 (100%)

Time: 00:56.384, Memory: 72.00 MB

OK, but incomplete, skipped, or risky tests!
Tests: 115, Assertions: 232, Skipped: 29.
```

After 59cda8c238b3aedfa4fd5d3224aba56eef2cbca0:
```
/usr/share/nginx/www/moodle $ php vendor/bin/phpunit --color mod/quiz/tests/backup/repeated_restore_test.php
Moodle 4.5.3 (Build: 20250317), d069cb93378d39ee00ce5f30cc520aaee4ae496c
Php: 8.3.19, pgsql: 14.17, OS: Linux 6.13.8-arch1-1 x86_64
PHPUnit 9.6.18 by Sebastian Bergmann and contributors.

.....SSSS.SS..SS...S.S..................S....................S.  63 / 115 ( 54%)
..EEESSSSESSEESSEEESESEEEESEESESSESEEEEESEESEEEEEEEE            115 / 115 (100%)

Time: 00:43.563, Memory: 70.00 MB
```

---

The cause was:

```
Undefined array key "coderunner_testcases"

/usr/share/nginx/www/moodle/question/type/coderunner/backup/moodle2/restore_qtype_coderunner_plugin.class.php:154
```

Therefore a check for this is added to the respective function.