### PR TITLE
Make upgrade prototype only run when upgrade. Add prototype creation into unit test.

### DIFF
--- a/db/upgradelib.php
+++ b/db/upgradelib.php
@@ -86,6 +86,9 @@ function update_question_types() {
 function update_question_types_internal() {
     mtrace("Setting up CodeRunner question prototypes...");
     $result = false;
+    if (PHPUNIT_TEST) {
+        return $result;
+    }
     try {
         if (qtype_coderunner_util::using_mod_qbank()) {
             $result = update_question_types_with_qbank();

--- a/tests/graphui_save_test.php
+++ b/tests/graphui_save_test.php
@@ -40,6 +40,7 @@ class graphui_save_test extends \qtype_coderunner_testcase {
     protected $qtype;
 
     protected function setUp(): void {
+        parent::setUp();
         $this->resetAfterTest(true);
         $this->qtype = new \qtype_coderunner();
     }

--- a/tests/penaltyregime_test.php
+++ b/tests/penaltyregime_test.php
@@ -32,7 +32,7 @@ global $CFG;
 require_once($CFG->dirroot . '/question/engine/tests/helpers.php');
 require_once($CFG->dirroot . '/question/type/coderunner/tests/test.php');
 require_once($CFG->dirroot . '/question/type/coderunner/tests/helper.php');
-
+require_once($CFG->dirroot . '/question/type/coderunner/tests/walkthrough_testbase.php');
 /**
  * More extensive testing of penalty regime.
  *
@@ -41,7 +41,7 @@ require_once($CFG->dirroot . '/question/type/coderunner/tests/helper.php');
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-class penaltyregime_test extends \qbehaviour_walkthrough_test_base {
+class penaltyregime_test extends walkthrough_testbase {
     protected function setUp(): void {
         parent::setUp();
         \qtype_coderunner_testcase::setup_test_sandbox_configuration();

--- a/tests/precheckwalkthrough_test.php
+++ b/tests/precheckwalkthrough_test.php
@@ -32,13 +32,14 @@ global $CFG;
 require_once($CFG->dirroot . '/question/engine/tests/helpers.php');
 require_once($CFG->dirroot . '/question/type/coderunner/tests/test.php');
 require_once($CFG->dirroot . '/question/type/coderunner/question.php');
+require_once($CFG->dirroot . '/question/type/coderunner/tests/walkthrough_testbase.php');
 
 use qtype_coderunner\constants;
 
 /**
  * @coversNothing
  */
-class precheckwalkthrough_test extends \qbehaviour_walkthrough_test_base {
+class precheckwalkthrough_test extends walkthrough_testbase {
     protected function setUp(): void {
         parent::setUp();
         \qtype_coderunner_testcase::setup_test_sandbox_configuration();

--- a/tests/test.php
+++ b/tests/test.php
@@ -29,7 +29,7 @@ defined('MOODLE_INTERNAL') || die();
 global $CFG;
 require_once($CFG->dirroot . '/question/engine/tests/helpers.php');
 require_once($CFG->dirroot . '/question/type/coderunner/question.php');
-
+require_once($CFG->dirroot . '/question/type/coderunner/db/upgradelib.php');
 /**
  * @coversNothing
  */
@@ -39,11 +39,22 @@ class qtype_coderunner_testcase extends advanced_testcase {
     /** @var stdClass Holds question category.*/
     protected $category;
 
+    protected static bool $prototypesinstalled = false;
+
     protected function setUp(): void {
         parent::setUp();
         self::setup_test_sandbox_configuration();
-        $this->resetAfterTest(false);
+        $this->resetAfterTest(true);
         $this->setAdminUser();
+        ob_start();
+        if (!self::$prototypesinstalled) {
+            if (\qtype_coderunner_util::using_mod_qbank()) {
+                update_question_types_with_qbank();
+            } else {
+                update_question_types_legacy();
+            }
+        }
+        ob_end_clean();
         $generator = $this->getDataGenerator()->get_plugin_generator('core_question');
         $this->category = $generator->create_question_category([]);
     }

--- a/tests/walkthrough_combinator_grader_test.php
+++ b/tests/walkthrough_combinator_grader_test.php
@@ -32,6 +32,7 @@ defined('MOODLE_INTERNAL') || die();
 global $CFG;
 require_once($CFG->dirroot . '/question/engine/tests/helpers.php');
 require_once($CFG->dirroot . '/question/type/coderunner/tests/test.php');
+require_once($CFG->dirroot . '/question/type/coderunner/tests/walkthrough_testbase.php');
 
 /**
  * Unit tests for the coderunner question type.
@@ -40,7 +41,7 @@ require_once($CFG->dirroot . '/question/type/coderunner/tests/test.php');
  * @copyright  2011, 2020 The Open University
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class walkthrough_combinator_grader_test extends \qbehaviour_walkthrough_test_base {
+class walkthrough_combinator_grader_test extends walkthrough_testbase {
     protected function setUp(): void {
         global $CFG;
         parent::setUp();

--- a/tests/walkthrough_display_feedback_test.php
+++ b/tests/walkthrough_display_feedback_test.php
@@ -22,7 +22,7 @@ global $CFG;
 require_once($CFG->dirroot . '/question/engine/tests/helpers.php');
 require_once($CFG->dirroot . '/question/type/coderunner/tests/test.php');
 require_once($CFG->dirroot . '/question/type/coderunner/question.php');
-
+require_once($CFG->dirroot . '/question/type/coderunner/tests/walkthrough_testbase.php');
 
 /**
  * Use a walkthrough test to validate the new (2019) display-feedback options.
@@ -33,7 +33,7 @@ require_once($CFG->dirroot . '/question/type/coderunner/question.php');
  * @copyright  2019 Richard Lobb, The University of Canterbury
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class walkthrough_display_feedback_test extends \qbehaviour_walkthrough_test_base {
+class walkthrough_display_feedback_test extends walkthrough_testbase {
     protected function setUp(): void {
         parent::setUp();
         \qtype_coderunner_testcase::setup_test_sandbox_configuration();

--- a/tests/walkthrough_extras_test.php
+++ b/tests/walkthrough_extras_test.php
@@ -24,6 +24,7 @@ global $CFG;
 require_once($CFG->dirroot . '/question/engine/tests/helpers.php');
 require_once($CFG->dirroot . '/question/type/coderunner/tests/test.php');
 require_once($CFG->dirroot . '/question/type/coderunner/question.php');
+require_once($CFG->dirroot . '/question/type/coderunner/tests/walkthrough_testbase.php');
 
 define('PRELOAD_TEST', "# TEST COMMENT TO CHECK PRELOAD IS WORKING\n");
 
@@ -38,7 +39,7 @@ define('PRELOAD_TEST', "# TEST COMMENT TO CHECK PRELOAD IS WORKING\n");
  * @copyright  2012, 2014 Richard Lobb, The University of Canterbury
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class walkthrough_extras_test extends \qbehaviour_walkthrough_test_base {
+class walkthrough_extras_test extends walkthrough_testbase {
     protected function setUp(): void {
         parent::setUp();
         \qtype_coderunner_testcase::setup_test_sandbox_configuration();

--- a/tests/walkthrough_multilang_test.php
+++ b/tests/walkthrough_multilang_test.php
@@ -24,7 +24,7 @@ global $CFG;
 require_once($CFG->dirroot . '/question/engine/tests/helpers.php');
 require_once($CFG->dirroot . '/question/type/coderunner/tests/test.php');
 require_once($CFG->dirroot . '/question/type/coderunner/question.php');
-
+require_once($CFG->dirroot . '/question/type/coderunner/tests/walkthrough_testbase.php');
 
 /**
  * A walkthrough of a simple multilanguage question that asks for a program
@@ -37,7 +37,7 @@ require_once($CFG->dirroot . '/question/type/coderunner/question.php');
  * @copyright  2018 Richard Lobb, The University of Canterbury
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class walkthrough_multilang_test extends \qbehaviour_walkthrough_test_base {
+class walkthrough_multilang_test extends walkthrough_testbase {
     protected function setUp(): void {
         parent::setUp();
         \qtype_coderunner_testcase::setup_test_sandbox_configuration();

--- a/tests/walkthrough_randomisation_test.php
+++ b/tests/walkthrough_randomisation_test.php
@@ -22,6 +22,7 @@ global $CFG;
 require_once($CFG->dirroot . '/question/engine/tests/helpers.php');
 require_once($CFG->dirroot . '/question/type/coderunner/tests/test.php');
 require_once($CFG->dirroot . '/question/type/coderunner/question.php');
+require_once($CFG->dirroot . '/question/type/coderunner/tests/walkthrough_testbase.php');
 
 /**
  * Further walkthrough tests for the CodeRunner plugin, testing the
@@ -33,7 +34,7 @@ require_once($CFG->dirroot . '/question/type/coderunner/question.php');
  * @copyright  2018 Richard Lobb, The University of Canterbury
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class walkthrough_randomisation_test extends \qbehaviour_walkthrough_test_base {
+class walkthrough_randomisation_test extends walkthrough_testbase {
     protected function setUp(): void {
         parent::setUp();
         \qtype_coderunner_testcase::setup_test_sandbox_configuration();

--- a/tests/walkthrough_test.php
+++ b/tests/walkthrough_test.php
@@ -31,6 +31,8 @@ defined('MOODLE_INTERNAL') || die();
 global $CFG;
 require_once($CFG->dirroot . '/question/engine/tests/helpers.php');
 require_once($CFG->dirroot . '/question/type/coderunner/tests/test.php');
+require_once($CFG->dirroot . '/question/type/coderunner/question.php');
+require_once($CFG->dirroot . '/question/type/coderunner/tests/walkthrough_testbase.php');
 
 /**
  * Unit tests for the coderunner question type.
@@ -38,7 +40,7 @@ require_once($CFG->dirroot . '/question/type/coderunner/tests/test.php');
  * @copyright  2011 The Open University
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class walkthrough_test extends \qbehaviour_walkthrough_test_base {
+class walkthrough_test extends walkthrough_testbase {
     protected function setUp(): void {
         parent::setUp();
         \qtype_coderunner_testcase::setup_test_sandbox_configuration();
@@ -117,6 +119,8 @@ class walkthrough_test extends \qbehaviour_walkthrough_test_base {
         $user = $generator->create_user();
         $coursecontext = \context_course::instance($course->id);
         $generator->enrol_user($user->id, $course->id, 'editingteacher');
+        // Reset the page after we installed the prototypes.
+        $PAGE->reset_theme_and_output();
         $this->setUser($user);
         $PAGE->set_course($course);
 

--- a/tests/walkthrough_testbase.php
+++ b/tests/walkthrough_testbase.php
@@ -1,0 +1,63 @@
+<?php
+// This file is part of CodeRunner - http://coderunner.org.nz/
+//
+// CodeRunner is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// CodeRunner is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with CodeRunner.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Walkthrough base for the coderunner question type.
+ * @group qtype_coderunner
+ *
+ * @package    qtype
+ * @subpackage coderunner
+ * @copyright  2011, 2020 The Open University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+namespace qtype_coderunner;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->dirroot . '/question/engine/tests/helpers.php');
+require_once($CFG->dirroot . '/question/type/coderunner/tests/test.php');
+require_once($CFG->dirroot . '/question/type/coderunner/db/upgradelib.php');
+
+/**
+ * Walkthrough base for the coderunner question type.
+ *
+ * @coversNothing
+ * @copyright  2011, 2020 The Open University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class walkthrough_testbase extends \qbehaviour_walkthrough_test_base {
+    protected static bool $prototypesinstalled = false;
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+        ob_start();
+        if (!self::$prototypesinstalled) {
+            if (\qtype_coderunner_util::using_mod_qbank()) {
+                update_question_types_with_qbank();
+            } else {
+                update_question_types_legacy();
+            }
+        }
+        ob_end_clean();
+    }
+
+    public function test_dummy_walkthrough_testbase(): void {
+        /* Present to avoid a warning about no testcases. */
+    }
+}


### PR DESCRIPTION
Hi @trampgeek ,

There are some core unit test failures when installing qtype_coderunner on Moodle 5.0+.
The issue occurs because the prototype upgrade steps automatically add a new category during unit test execution which causing other test to fail.

To resolve this, I’ve modified the upgrade process to skip that step when running unit tests.
Unit tests should handle their own data setup before execution.

Could you please review the changes?