### PR TITLE
Remove duplicated behat test.

### DIFF
--- a/tests/behat/make_combinator_prototype.feature
+++ b/tests/behat/make_combinator_prototype.feature
@@ -66,7 +66,7 @@ Feature: make_combinator_prototype
     And I should not see "Write a sqr function"
     And I should see "Combinator prototype tester"
 
-  Scenario: As a teacher, I get marked right (using combinator template) if I submit a correct answer to a CodeRunner question
+  Scenario: As a teacher, I get marked right (using twig combinator template) if I submit a correct answer to a CodeRunner question
     When I choose "Preview" action for "Combinator prototype tester" in the question bank
     And I click on "a[aria-controls='id_attemptoptionsheadercontainer']" "css_element"
     And I set the field "id_behaviour" to "Adaptive mode"


### PR DESCRIPTION
Hi @trampgeek , I noticed duplicated naming in another test (tests/behat/test_combinator_grader.feature). After checking the content, it appears those Behat tests are duplicating coverage of the same feature, so I removed them.

Could you please review the changes?