### PR TITLE
Fix PHPUnit test when running without config

### DIFF
--- a/tests/helper.php
+++ b/tests/helper.php
@@ -27,8 +27,6 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot . '/question/type/coderunner/tests/test.php');
 
-qtype_coderunner_testcase::setup_test_sandbox_configuration();
-
 // Special class of exception thrown when the helper is asked to construct
 // a CodeRunner question of a type for which no prototype exists.
 // This may occur if, say Matlab has been installed in a sandbox but the

--- a/tests/test.php
+++ b/tests/test.php
@@ -33,7 +33,7 @@ require_once($CFG->dirroot . '/question/type/coderunner/db/upgradelib.php');
 /**
  * @coversNothing
  */
-class qtype_coderunner_testcase extends advanced_testcase {
+abstract class qtype_coderunner_testcase extends advanced_testcase {
     protected $hasfailed = false; // Set to true when a test fails.
 
     /** @var stdClass Holds question category.*/
@@ -71,7 +71,7 @@ class qtype_coderunner_testcase extends advanced_testcase {
         if (is_readable($localconfig)) {
             require($localconfig);
         } else {
-            throw new coding_exception('tests/fixtures/test-sandbox-config.php must exist to define test configuration');
+            self::markTestSkipped('tests/fixtures/test-sandbox-config.php must exist to define test configuration');
         }
         $USER->username  = 'tester';
         $USER->email     = 'tester@nowhere.com';


### PR DESCRIPTION
As of now the PHPUnit tests throw an exception when executed without a valid config, this PR change this so that they are skipped instead. This prevents them from breaking running the full stake of phpnunit tests on a moodle codebase including this plugin.